### PR TITLE
fix: 限制工具循环局部上下文预算

### DIFF
--- a/tests/agent/test_llm_client_streaming.py
+++ b/tests/agent/test_llm_client_streaming.py
@@ -63,7 +63,10 @@ def test_model_context_cap_compacts_one_oversized_recent_message():
 
 
 def test_tool_loop_context_stays_within_hot_budget_and_keeps_tool_exchanges():
-    from vulnclaw.agent.llm_client import _fit_tool_loop_context
+    from vulnclaw.agent.llm_client import (
+        _fit_tool_loop_context,
+        _tool_loop_target_budget,
+    )
     from vulnclaw.agent.token_counter import estimate_tokens
 
     agent = SimpleNamespace(context=SimpleNamespace(max_tokens=1_200))
@@ -94,7 +97,92 @@ def test_tool_loop_context_stays_within_hot_budget_and_keeps_tool_exchanges():
 
     fitted = _fit_tool_loop_context(agent, messages, round_message)
 
-    assert estimate_tokens(fitted) <= 1_200
+    assert _tool_loop_target_budget(agent) == 1_024
+    assert estimate_tokens(fitted) <= _tool_loop_target_budget(agent)
+    assert round_message in fitted
+    for index, message in enumerate(fitted):
+        if message.get("role") == "tool":
+            predecessor = fitted[index - 1]
+            assert predecessor.get("role") == "assistant"
+            assert message["tool_call_id"] in {
+                item["id"] for item in predecessor["tool_calls"]
+            }
+
+
+def test_tool_loop_uses_stable_prefix_until_high_water_then_falls_to_target():
+    from vulnclaw.agent.llm_client import (
+        _build_tool_loop_messages,
+        _fit_tool_loop_context,
+        _tool_loop_hot_budget,
+        _tool_loop_target_budget,
+    )
+    from vulnclaw.agent.token_counter import estimate_tokens
+
+    history = [
+        {"role": "user", "content": "previous evidence " + "h" * 2_000},
+        {"role": "assistant", "content": "previous assessment " + "a" * 2_000},
+    ]
+    agent = SimpleNamespace(
+        context=SimpleNamespace(max_tokens=3_200, get_messages=lambda: list(history))
+    )
+    messages, round_message = _build_tool_loop_messages(
+        agent,
+        "system contract",
+        "current task must remain visible",
+        include_history=True,
+    )
+    stable_prefix = list(messages)
+    assert _tool_loop_hot_budget(agent) == 3_200
+    assert _tool_loop_target_budget(agent) == 2_600
+
+    messages.extend(
+        [
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "under-high-water",
+                        "type": "function",
+                        "function": {"name": "probe", "arguments": "{}"},
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "under-high-water",
+                "content": "r" * 2_000,
+            },
+        ]
+    )
+    assert estimate_tokens(messages) < _tool_loop_hot_budget(agent)
+    assert _fit_tool_loop_context(agent, messages, round_message) is messages
+    assert messages[:len(stable_prefix)] == stable_prefix
+
+    for number in range(2):
+        call_id = f"overflow-{number}"
+        messages.extend(
+            [
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": call_id,
+                            "type": "function",
+                            "function": {"name": "probe", "arguments": "{}"},
+                        }
+                    ],
+                },
+                {"role": "tool", "tool_call_id": call_id, "content": "r" * 4_000},
+            ]
+        )
+
+    assert estimate_tokens(messages) > _tool_loop_hot_budget(agent)
+    fitted = _fit_tool_loop_context(agent, messages, round_message)
+
+    assert estimate_tokens(fitted) <= _tool_loop_target_budget(agent)
+    assert fitted[0] == stable_prefix[0]
     assert round_message in fitted
     for index, message in enumerate(fitted):
         if message.get("role") == "tool":

--- a/tests/agent/test_llm_client_streaming.py
+++ b/tests/agent/test_llm_client_streaming.py
@@ -62,6 +62,49 @@ def test_model_context_cap_compacts_one_oversized_recent_message():
     assert "active context compacted" in fitted[-1]["content"]
 
 
+def test_tool_loop_context_stays_within_hot_budget_and_keeps_tool_exchanges():
+    from vulnclaw.agent.llm_client import _fit_tool_loop_context
+    from vulnclaw.agent.token_counter import estimate_tokens
+
+    agent = SimpleNamespace(context=SimpleNamespace(max_tokens=1_200))
+    round_message = {"role": "user", "content": "current task must remain visible"}
+    messages = [
+        {"role": "system", "content": "system contract"},
+        {"role": "user", "content": "old context " + "x" * 4_000},
+        round_message,
+    ]
+    for number in range(3):
+        call_id = f"call-{number}"
+        messages.append(
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": call_id,
+                        "type": "function",
+                        "function": {"name": "probe", "arguments": "{}"},
+                    }
+                ],
+            }
+        )
+        messages.append(
+            {"role": "tool", "tool_call_id": call_id, "content": "r" * 2_000}
+        )
+
+    fitted = _fit_tool_loop_context(agent, messages, round_message)
+
+    assert estimate_tokens(fitted) <= 1_200
+    assert round_message in fitted
+    for index, message in enumerate(fitted):
+        if message.get("role") == "tool":
+            predecessor = fitted[index - 1]
+            assert predecessor.get("role") == "assistant"
+            assert message["tool_call_id"] in {
+                item["id"] for item in predecessor["tool_calls"]
+            }
+
+
 class TestNullSink:
     """Test _NullSink has no side effects."""
 

--- a/vulnclaw/agent/llm_client.py
+++ b/vulnclaw/agent/llm_client.py
@@ -36,7 +36,11 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-from vulnclaw.agent.token_counter import estimate_tokens, truncate_messages  # noqa: E402
+from vulnclaw.agent.token_counter import (  # noqa: E402
+    estimate_tokens,
+    group_tool_exchanges,
+    truncate_messages,
+)
 from vulnclaw.agent.tool_call_manager import (  # noqa: E402
     handle_tool_calls,
     handle_tool_calls_with_results,
@@ -94,6 +98,75 @@ def _fit_context_window(agent: AgentContext, messages: list[dict[str, Any]]) -> 
     except Exception:
         logger.warning("上下文截断: %d → %d tokens (预算 %d)", current, estimate_tokens(trimmed), budget)
     return trimmed
+
+
+def _tool_loop_hot_budget(agent: AgentContext) -> int:
+    """Return the bounded working-set budget for one internal tool loop."""
+    context = getattr(agent, "context", None)
+    budget = getattr(context, "max_tokens", 32_000)
+    if not isinstance(budget, (int, float)) or isinstance(budget, bool):
+        return 32_000
+    return max(1_024, int(budget))
+
+
+def _fit_tool_loop_context(
+    agent: AgentContext,
+    messages: list[dict[str, Any]],
+    round_message: dict[str, Any],
+) -> list[dict[str, Any]]:
+    """Keep one tool-loop request inside the hot budget without breaking tools.
+
+    ``ContextManager`` bounds persisted history, but a single ``call_llm_auto``
+    can append several assistant/tool exchanges before it returns.  Compact that
+    local working set after every tool batch, while preserving the system
+    prompt, current task instruction, and complete recent tool exchanges.
+    """
+    budget = _tool_loop_hot_budget(agent)
+    if estimate_tokens(messages) <= budget:
+        return messages
+
+    try:
+        round_index = next(
+            index for index, message in enumerate(messages) if message is round_message
+        )
+    except StopIteration:
+        return truncate_messages(messages, budget, preserve_system=True)
+
+    system_messages = (
+        [messages[0]] if messages and messages[0].get("role") == "system" else []
+    )
+    history_start = len(system_messages)
+    history = messages[history_start:round_index]
+    tool_loop = messages[round_index + 1 :]
+    required = [*system_messages, round_message]
+    if estimate_tokens(required) >= budget:
+        return truncate_messages(required, budget, preserve_system=True, min_recent=1)
+
+    running = estimate_tokens(required)
+
+    def keep_recent(
+        groups: list[list[dict[str, Any]]],
+    ) -> list[list[dict[str, Any]]]:
+        nonlocal running
+        kept: list[list[dict[str, Any]]] = []
+        for group in reversed(groups):
+            cost = estimate_tokens(group)
+            if running + cost > budget:
+                break
+            running += cost
+            kept.insert(0, group)
+        return kept
+
+    # Prefer the evidence acquired in this still-active tool loop, then fill
+    # remaining space with older persistent history.
+    kept_tool_loop = keep_recent(group_tool_exchanges(tool_loop))
+    kept_history = keep_recent(group_tool_exchanges(history))
+    return [
+        *system_messages,
+        *(message for group in kept_history for message in group),
+        round_message,
+        *(message for group in kept_tool_loop for message in group),
+    ]
 
 
 def _resolve_auto_tool_rounds(agent: AgentContext, max_tool_rounds: int | None = None) -> int:
@@ -515,7 +588,8 @@ async def call_llm_auto(
     messages = [{"role": "system", "content": system_prompt}]
     if include_history:
         messages.extend(agent.context.get_messages())
-    messages.append({"role": "user", "content": round_context})
+    round_message = {"role": "user", "content": round_context}
+    messages.append(round_message)
     messages = _fit_context_window(agent, messages)
     tools = agent._build_openai_tools()
 
@@ -577,6 +651,7 @@ async def call_llm_auto(
         tool_messages = _tool_result_messages(tool_results)
         messages.append(assistant_message)
         messages.extend(tool_messages)
+        messages = _fit_tool_loop_context(agent, messages, round_message)
         if include_history:
             _append_context_message(agent, assistant_message)
             for tool_message in tool_messages:
@@ -879,7 +954,8 @@ async def call_llm_auto_stream(
     messages = [{"role": "system", "content": system_prompt}]
     if include_history:
         messages.extend(agent.context.get_messages())
-    messages.append({"role": "user", "content": round_context})
+    round_message = {"role": "user", "content": round_context}
+    messages.append(round_message)
     messages = _fit_context_window(agent, messages)
     tools = agent._build_openai_tools()
 
@@ -921,6 +997,7 @@ async def call_llm_auto_stream(
             tool_messages = _tool_result_messages(tool_results)
             messages.append(assistant_message)
             messages.extend(tool_messages)
+            messages = _fit_tool_loop_context(agent, messages, round_message)
             if include_history:
                 _append_context_message(agent, assistant_message)
                 for tool_message in tool_messages:

--- a/vulnclaw/agent/llm_client.py
+++ b/vulnclaw/agent/llm_client.py
@@ -48,6 +48,7 @@ from vulnclaw.agent.tool_call_manager import (  # noqa: E402
 
 _CONTEXT_USABLE_RATIO = 0.9
 _DEFAULT_AUTO_TOOL_ROUNDS = 6
+_TOOL_LOOP_TARGET_RATIO = 26_000 / 32_000
 _SYNC_STREAM_END = object()
 
 
@@ -101,7 +102,7 @@ def _fit_context_window(agent: AgentContext, messages: list[dict[str, Any]]) -> 
 
 
 def _tool_loop_hot_budget(agent: AgentContext) -> int:
-    """Return the bounded working-set budget for one internal tool loop."""
+    """Return the high-water mark for one internal tool-loop working set."""
     context = getattr(agent, "context", None)
     budget = getattr(context, "max_tokens", 32_000)
     if not isinstance(budget, (int, float)) or isinstance(budget, bool):
@@ -109,28 +110,59 @@ def _tool_loop_hot_budget(agent: AgentContext) -> int:
     return max(1_024, int(budget))
 
 
+def _tool_loop_target_budget(agent: AgentContext) -> int:
+    """Return the post-compaction target, 26K for the default 32K high-water mark."""
+    high_water = _tool_loop_hot_budget(agent)
+    return min(high_water, max(1_024, int(high_water * _TOOL_LOOP_TARGET_RATIO)))
+
+
+def _build_tool_loop_messages(
+    agent: AgentContext,
+    system_prompt: str,
+    round_context: str,
+    *,
+    include_history: bool,
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    """Build a stable prefix followed by the mutable internal tool-loop tail.
+
+    The prefix is created once per ``call_llm_auto`` invocation and never
+    reordered while its tool loop runs: system prompt, bounded hot history,
+    then the current task instruction.  Assistant/tool exchanges are appended
+    after it as the mutable tail.  This lets providers reuse the unchanged
+    prefix between tool rounds until a high-water compaction is necessary.
+    """
+    messages = [{"role": "system", "content": system_prompt}]
+    if include_history:
+        messages.extend(agent.context.get_messages())
+    round_message = {"role": "user", "content": round_context}
+    messages.append(round_message)
+    return messages, round_message
+
+
 def _fit_tool_loop_context(
     agent: AgentContext,
     messages: list[dict[str, Any]],
     round_message: dict[str, Any],
 ) -> list[dict[str, Any]]:
-    """Keep one tool-loop request inside the hot budget without breaking tools.
+    """Compact an oversized tool-loop tail without breaking tool exchanges.
 
     ``ContextManager`` bounds persisted history, but a single ``call_llm_auto``
     can append several assistant/tool exchanges before it returns.  Compact that
-    local working set after every tool batch, while preserving the system
-    prompt, current task instruction, and complete recent tool exchanges.
+    local working set only after it crosses the high-water mark.  It then falls
+    back to a lower target (26K for the default 32K high-water mark), preserving
+    the stable system/task prefix and complete recent tool exchanges.
     """
-    budget = _tool_loop_hot_budget(agent)
-    if estimate_tokens(messages) <= budget:
+    high_water = _tool_loop_hot_budget(agent)
+    if estimate_tokens(messages) <= high_water:
         return messages
+    target = _tool_loop_target_budget(agent)
 
     try:
         round_index = next(
             index for index, message in enumerate(messages) if message is round_message
         )
     except StopIteration:
-        return truncate_messages(messages, budget, preserve_system=True)
+        return truncate_messages(messages, target, preserve_system=True)
 
     system_messages = (
         [messages[0]] if messages and messages[0].get("role") == "system" else []
@@ -139,8 +171,8 @@ def _fit_tool_loop_context(
     history = messages[history_start:round_index]
     tool_loop = messages[round_index + 1 :]
     required = [*system_messages, round_message]
-    if estimate_tokens(required) >= budget:
-        return truncate_messages(required, budget, preserve_system=True, min_recent=1)
+    if estimate_tokens(required) >= target:
+        return truncate_messages(required, target, preserve_system=True, min_recent=1)
 
     running = estimate_tokens(required)
 
@@ -151,7 +183,7 @@ def _fit_tool_loop_context(
         kept: list[list[dict[str, Any]]] = []
         for group in reversed(groups):
             cost = estimate_tokens(group)
-            if running + cost > budget:
+            if running + cost > target:
                 break
             running += cost
             kept.insert(0, group)
@@ -585,11 +617,12 @@ async def call_llm_auto(
             max_tool_rounds=max_tool_rounds,
         )
 
-    messages = [{"role": "system", "content": system_prompt}]
-    if include_history:
-        messages.extend(agent.context.get_messages())
-    round_message = {"role": "user", "content": round_context}
-    messages.append(round_message)
+    messages, round_message = _build_tool_loop_messages(
+        agent,
+        system_prompt,
+        round_context,
+        include_history=include_history,
+    )
     messages = _fit_context_window(agent, messages)
     tools = agent._build_openai_tools()
 
@@ -951,11 +984,12 @@ async def call_llm_auto_stream(
     if stream_sink is None:
         stream_sink = _NullSink()
 
-    messages = [{"role": "system", "content": system_prompt}]
-    if include_history:
-        messages.extend(agent.context.get_messages())
-    round_message = {"role": "user", "content": round_context}
-    messages.append(round_message)
+    messages, round_message = _build_tool_loop_messages(
+        agent,
+        system_prompt,
+        round_context,
+        include_history=include_history,
+    )
     messages = _fit_context_window(agent, messages)
     tools = agent._build_openai_tools()
 


### PR DESCRIPTION
## 问题

solve 模式会在单次模型请求的内部工具循环中持续追加 `assistant(tool_calls)` 与 `tool(result)` 消息。

这些局部消息若持续增长，可能触发全局上下文截断；若每次刚超过上限就只裁到上限附近，又会频繁改变历史上下文，降低 Prompt Cache 的复用率。

## 修复

- 工具循环采用 32,000 tokens 高水位、26,000 tokens 目标水位：仅超过高水位时触发压缩，并一次回落到目标附近。
- 将一次 solve 调用中的 `system prompt + 热历史 + 当前任务` 作为稳定前缀；新产生的完整工具交换组只追加在可变尾部。
- 裁剪时优先保留当前工具循环中最新的完整 `assistant(tool_calls) + tool(result)` 交换组，再用剩余预算保留较新的热历史。
- 同步与流式 `call_llm_auto` 路径均使用相同的前缀和水位策略。

## 验证

- 新增稳定前缀、高水位触发、26K 目标回落和工具交换完整性的回归测试。
- LLM 流式、失败切换、流式健壮性和 token 测试：87 项通过。
- Agent、solve 和循环控制回归测试：136 项通过。
- Ruff 与 `git diff --check` 通过。