### PR TITLE
fix(cli): 修复 REPL 持续模式提示词元组错误 #163

### DIFF
--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -190,7 +190,7 @@ class TestCLI:
         new_state = SessionState(target="https://new.example")
         new_state.advance_phase(PentestPhase.EXPLOITATION)
 
-        observed: dict[str, str] = {}
+        observed: dict[str, object] = {}
 
         monkeypatch.setattr(cli_main, "load_config", lambda: config)
         monkeypatch.setattr(
@@ -235,6 +235,7 @@ class TestCLI:
             )()
 
         async def fake_persistent_pentest(self, user_input: str, target=None, **kwargs):
+            observed["user_input"] = user_input
             observed["target_arg"] = target or ""
             observed["state_target"] = self.context.state.target or ""
             observed["phase"] = self.context.state.phase.value
@@ -253,6 +254,8 @@ class TestCLI:
         assert observed["target_arg"] == "https://new.example"
         assert observed["state_target"] == "https://new.example"
         assert observed["phase"] == PentestPhase.EXPLOITATION.value
+        assert isinstance(observed["user_input"], str)
+        assert "https://new.example" in observed["user_input"]
 
     def test_report_target_mode(self, runner, monkeypatch, tmp_path):
         import vulnclaw.target_state.store as store_mod

--- a/vulnclaw/cli/main.py
+++ b/vulnclaw/cli/main.py
@@ -460,8 +460,8 @@ def _run_repl() -> None:
                 )
 
                 persistent_prompt = (
-                    f"Perform an authorized persistent penetration test against {persistent_target}. ",
-                    _("cli.target_within_range_and_explicitly_authorized")
+                    f"Perform an authorized persistent penetration test against {persistent_target}. "
+                    + _("cli.target_within_range_and_explicitly_authorized")
                 )
 
                 all_cycle_results: list[PersistentCycleResult] = []


### PR DESCRIPTION
## 变更

- 修复 REPL `persistent` 命令将提示词片段误构造成元组的问题。
- 扩展 CLI 回归测试，验证传给 `persistent_pentest` 的提示词是字符串并包含目标地址。

## 原因

`persistent_prompt` 的两个表达式之间使用了逗号，运行时得到 `tuple[str, str]`；`_reset_runtime_state()` 对其调用 `.lower()` 时会抛出 `AttributeError`。

## 验证

- `ruff check vulnclaw tests`
- `pytest -q tests/cli/test_cli.py`：108 passed
- 全量 `pytest -q` 跑至 Web 用例 `test_web_task_service_blocks_run_when_allowed_actions_conflict` 时挂起；该用例单独运行同样挂起，与本次 REPL 改动无关。

Fixes #163
