### PR TITLE
security: close static-check bypass + add kernel rlimits + opt-in container sandbox

### DIFF
--- a/vulnclaw/agent/builtin_tools.py
+++ b/vulnclaw/agent/builtin_tools.py
@@ -71,7 +71,14 @@ def role_allows_tool(role: str | None, tool_name: str) -> bool:
 
 BLOCKED_PATTERNS: list[str] = [
     r"os\.\s*system\s*\(",
+    r"os\.\s*popen[234]?\s*\(",
+    r"os\.\s*posix_spawn[p]?\s*\(",
+    r"os\.\s*spawn[lv][ep]{0,2}\s*\(",
+    r"os\.\s*fork(pty)?\s*\(",
+    r"os\.\s*exec[lv][ep]{0,2}\s*\(",
     r"subprocess\.\s*Popen\s*\(",
+    r"subprocess\.\s*(run|call|check_call|check_output)\s*\(",
+    r"pty\.\s*spawn\s*\(",
     r"shutil\.\s*rmtree\s*\(",
     r"__import__\s*\(\s*['\"]os['\"]",
     r"open\s*\(\s*['\"].*vulnclaw.*config",
@@ -90,7 +97,8 @@ BLOCKED_PATTERNS: list[str] = [
 _DANGEROUS_MODULES = frozenset({
     "os", "subprocess", "shutil", "sys", "socket",
     "http", "urllib", "requests", "ftplib", "smtplib",
-    "pathlib", "importlib",
+    "pathlib", "importlib", "pty", "ctypes", "multiprocessing",
+    "posix", "signal", "resource",
 })
 
 _DANGEROUS_BUILTIN_NAMES = frozenset({
@@ -98,6 +106,34 @@ _DANGEROUS_BUILTIN_NAMES = frozenset({
     "getattr", "setattr", "delattr", "globals", "locals",
     "vars", "dir", "type",
 })
+
+# 修改者: security-hardening pass
+# 修改原因: the old blocklist only matched `subprocess.Popen(` — every other
+# process-spawning entry point on these modules (subprocess.run/call/
+# check_call/check_output, os.system/popen/posix_spawn/spawn*/fork/exec*,
+# pty.spawn) sailed straight through untouched, including in the default
+# "trusted-local" mode where SAFE_MODE_PATTERNS/LAB_MODE_PATTERNS are not
+# applied at all. Enumerate by (module, dangerous-attribute) pair instead of
+# growing an ad-hoc regex list per call spelling — this still cannot catch
+# every theoretical bypass (ctypes.CDLL(...).system(...), raw syscalls via
+# array-of-bytes shellcode, etc.) which is precisely why this check is
+# defense-in-depth layered under the kernel-enforced rlimits in
+# execute_python/execute_shell_command, not the only control.
+_DANGEROUS_MODULE_METHODS: dict[str, frozenset[str]] = {
+    "os": frozenset({
+        "system", "popen", "popen2", "popen3", "popen4",
+        "posix_spawn", "posix_spawnp",
+        "spawnl", "spawnle", "spawnlp", "spawnlpe",
+        "spawnv", "spawnve", "spawnvp", "spawnvpe",
+        "fork", "forkpty",
+        "execl", "execle", "execlp", "execlpe",
+        "execv", "execve", "execvp", "execvpe",
+    }),
+    "subprocess": frozenset({"run", "call", "check_call", "check_output", "Popen"}),
+    "pty": frozenset({"spawn"}),
+    "shutil": frozenset({"rmtree"}),
+    "multiprocessing": frozenset({"Process"}),
+}
 
 
 def _ast_check_sandbox_bypass(code: str) -> str | None:
@@ -109,6 +145,8 @@ def _ast_check_sandbox_bypass(code: str) -> str | None:
     - exec("import os; os.system('id')")
     - getattr(__builtins__, "open")
     - getattr(alias, "attr") where alias is a dangerous module
+    - os.system(...) / subprocess.run(...) / os.popen(...) / pty.spawn(...)
+      and their aliased or `from X import Y` forms
     """
     try:
         tree = ast.parse(code)
@@ -117,11 +155,18 @@ def _ast_check_sandbox_bypass(code: str) -> str | None:
 
     # Pass 1: collect import aliases (import socket as s → s = socket)
     _alias_to_module: dict[str, str] = {}
+    # Pass 1b: collect `from module import attr [as alias]` -> (module, attr)
+    _from_import_to_target: dict[str, tuple[str, str]] = {}
     for node in ast.walk(tree):
         if isinstance(node, ast.Import):
             for alias in node.names:
                 local_name = alias.asname if alias.asname else alias.name
                 _alias_to_module[local_name] = alias.name.split(".")[0]
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            module_root = node.module.split(".")[0]
+            for alias in node.names:
+                local_name = alias.asname if alias.asname else alias.name
+                _from_import_to_target[local_name] = (module_root, alias.name)
 
     def _resolve_name(name: str) -> str | None:
         """Resolve a name to its real module, checking alias map."""
@@ -173,7 +218,22 @@ def _ast_check_sandbox_bypass(code: str) -> str | None:
                         if resolved:
                             return f"getattr on module '{resolved}' detected"
 
-        # 4. __builtins__ direct access
+            # 4. module.dangerous_method(...) — e.g. os.system(, subprocess.run(,
+            #    pty.spawn(, including aliased imports (import os as _o).
+            if isinstance(func, ast.Attribute) and isinstance(func.value, ast.Name):
+                resolved_module = _resolve_name(func.value.id)
+                if resolved_module and func.attr in _DANGEROUS_MODULE_METHODS.get(
+                    resolved_module, frozenset()
+                ):
+                    return f"{resolved_module}.{func.attr}() detected (process/exec spawn)"
+
+            # 5. bare name from `from subprocess import run` / `from os import system`
+            if isinstance(func, ast.Name) and func.id in _from_import_to_target:
+                module_root, orig_attr = _from_import_to_target[func.id]
+                if orig_attr in _DANGEROUS_MODULE_METHODS.get(module_root, frozenset()):
+                    return f"{module_root}.{orig_attr}() detected via 'from {module_root} import {orig_attr}'"
+
+        # 6. __builtins__ direct access
         if isinstance(node, ast.Attribute) and node.attr == "__builtins__":
             return "__builtins__ access detected"
         if isinstance(node, ast.Name) and node.id == "__builtins__":
@@ -316,6 +376,99 @@ def _validate_command_url_scope(agent: AgentContext, command: str) -> str | None
     return None
 
 
+def _current_uid_task_count() -> int:
+    """Best-effort count of extant processes/threads for our real UID.
+
+    RLIMIT_NPROC is enforced by the Linux kernel as a system-wide count for
+    the calling process's real UID — NOT scoped to this process's own
+    subtree. Setting an absolute small ceiling (e.g. 16) breaks completely
+    benign code (even a single `threading.Thread()`) on any host that
+    already runs many unrelated processes under the same user — verified
+    empirically: this dev machine runs ~220 processes/threads under one UID
+    from unrelated sessions, so a hardcoded cap of 16 made a bare thread
+    start fail with "can't start new thread" despite nothing malicious
+    happening. Sizing the new limit relative to what is already running
+    avoids punishing the sandboxed call for its neighbors' activity.
+    """
+    try:
+        my_uid = os.getuid()
+    except AttributeError:
+        return 0  # Windows; RLIMIT_NPROC is POSIX-only and not applied there.
+
+    total = 0
+    try:
+        proc_entries = os.listdir("/proc")
+    except OSError:
+        return 200  # /proc unavailable (non-Linux POSIX) — generous fallback.
+
+    for entry in proc_entries:
+        if not entry.isdigit():
+            continue
+        try:
+            with open(f"/proc/{entry}/status", encoding="utf-8", errors="ignore") as f:
+                threads = 1
+                uid_matches = False
+                for line in f:
+                    if line.startswith("Uid:"):
+                        parts = line.split()
+                        uid_matches = len(parts) > 1 and parts[1] == str(my_uid)
+                    elif line.startswith("Threads:"):
+                        parts = line.split()
+                        threads = int(parts[1]) if len(parts) > 1 else 1
+                if uid_matches:
+                    total += threads
+        except (OSError, ValueError):
+            continue
+    return total or 200
+
+
+def _resource_limit_preexec_fn(safety: Any) -> Any:
+    """Build a preexec_fn applying POSIX rlimits, or None (no-op) when unavailable.
+
+    Runs inside the forked child, before exec(), so the limits are enforced by
+    the kernel for the remaining lifetime of that process — they hold no
+    matter what the child executes, unlike the source-level pattern checks in
+    execute_python which only inspect the code we were told about.
+    """
+    if os.name == "nt" or safety is None:
+        return None
+    if not getattr(safety, "resource_limits_enabled", True):
+        return None
+
+    max_cpu = int(getattr(safety, "resource_limit_max_cpu_seconds", 30) or 30)
+    max_mem_bytes = int(getattr(safety, "resource_limit_max_memory_mb", 512) or 512) * 1024 * 1024
+    max_procs = int(getattr(safety, "resource_limit_max_processes", 16) or 16)
+    max_files = int(getattr(safety, "resource_limit_max_open_files", 256) or 256)
+
+    def _apply() -> None:
+        try:
+            import resource as _resource
+        except ImportError:
+            return
+
+        # RLIMIT_NPROC is a system-wide-per-UID ceiling on Linux, not a
+        # per-subtree one — size it as headroom above what's already
+        # running so unrelated processes under the same user don't cause
+        # this sandboxed call's own first thread/fork to fail immediately.
+        nproc_ceiling = _current_uid_task_count() + max_procs
+
+        for limit, value in (
+            (getattr(_resource, "RLIMIT_CPU", None), (max_cpu, max_cpu)),
+            (getattr(_resource, "RLIMIT_AS", None), (max_mem_bytes, max_mem_bytes)),
+            (getattr(_resource, "RLIMIT_NPROC", None), (nproc_ceiling, nproc_ceiling)),
+            (getattr(_resource, "RLIMIT_NOFILE", None), (max_files, max_files)),
+            (getattr(_resource, "RLIMIT_CORE", None), (0, 0)),
+        ):
+            if limit is None:
+                continue
+            try:
+                _resource.setrlimit(limit, value)
+            except (ValueError, OSError):
+                pass  # platform/container may already cap this lower; skip
+
+    return _apply
+
+
 def _shell_argv(command: str, shell_name: str) -> list[str] | str:
     normalized = (shell_name or "").strip().lower()
     if os.name == "nt":
@@ -351,6 +504,46 @@ async def execute_shell_command(agent: AgentContext, args: dict[str, Any]) -> st
     use_shell = os.name != "nt"
     env = {**os.environ, "PYTHONIOENCODING": "utf-8"}
     started = time.perf_counter()
+    safety = getattr(agent.config, "safety", None)
+    preexec_fn = _resource_limit_preexec_fn(safety)
+
+    container_mode = str(getattr(safety, "container_sandbox_mode", "off") or "off").strip().lower()
+    if container_mode in ("shell_command", "all"):
+        from vulnclaw.agent.sandbox import SandboxUnavailableError, run_shell_in_container
+
+        try:
+            sandbox_result = await run_shell_in_container(
+                command, safety=safety, timeout_s=timeout_ms / 1000, workdir=str(workdir)
+            )
+        except SandboxUnavailableError as exc:
+            return f"[!] {exc}"
+
+        elapsed_ms = sandbox_result.elapsed_ms
+        if sandbox_result.timed_out:
+            return (
+                f"[!] shell_command timed out after {timeout_ms}ms (container sandbox)\n"
+                f"Command: {command}\nWorkdir: {workdir}\n"
+                f"Output:\n{sandbox_result.stdout}{sandbox_result.stderr}"
+            )
+        parts = [
+            f"Command: {command}",
+            f"Workdir: {workdir} (container sandbox, read-only mount)",
+            f"Exit code: {sandbox_result.exit_code}",
+            f"Wall time: {elapsed_ms}ms",
+            "Output:",
+        ]
+        output = ""
+        if sandbox_result.stdout:
+            output += sandbox_result.stdout
+        if sandbox_result.stderr:
+            output += ("\n" if output else "") + "[stderr]\n" + sandbox_result.stderr
+        if not output:
+            output = "(no output)"
+        raw_output = "\n".join(parts + [output])
+        if max_output_chars > 0 and len(raw_output) > max_output_chars:
+            clip = max_output_chars // 2
+            return raw_output[:clip] + "\n...[truncated by max_output_chars]...\n" + raw_output[-clip:]
+        return raw_output
 
     try:
         loop = asyncio.get_running_loop()
@@ -366,6 +559,7 @@ async def execute_shell_command(agent: AgentContext, args: dict[str, Any]) -> st
                 errors="replace",
                 timeout=timeout_ms / 1000,
                 env=env,
+                preexec_fn=preexec_fn,
             ),
         )
     except subprocess.TimeoutExpired as exc:
@@ -1877,23 +2071,73 @@ async def execute_python(agent: AgentContext, args: dict[str, Any]) -> str:
         return f"[!] Sandbox bypass detected: {ast_bypass}"
 
     max_output_chars = getattr(safety, "python_execute_max_output_chars", 0)
+    preamble = (
+        "import sys, json, re, os, base64, hashlib, itertools, collections, datetime, struct, binascii, textwrap\n"
+        "try:\n    import requests\nexcept ImportError:\n    pass\n"
+        "try:\n    from bs4 import BeautifulSoup\nexcept ImportError:\n    pass\n"
+        "try:\n    from Crypto.Cipher import AES\nexcept ImportError:\n    pass\n\n"
+    )
+
+    container_mode = str(getattr(safety, "container_sandbox_mode", "off") or "off").strip().lower()
+    if container_mode in ("python_execute", "all"):
+        from vulnclaw.agent.sandbox import SandboxUnavailableError, run_python_in_container
+
+        try:
+            sandbox_result = await run_python_in_container(
+                code, safety=safety, timeout_s=timeout_seconds, preamble=preamble
+            )
+        except SandboxUnavailableError as exc:
+            _write_python_audit(
+                agent, purpose=purpose, code=code, mode=mode,
+                outcome="blocked", blocked_reason="sandbox_unavailable",
+            )
+            return f"[!] {exc}"
+
+        if sandbox_result.timed_out:
+            agent.runtime.python_timeout_rounds += 1
+            _write_python_audit(agent, purpose=purpose, code=code, mode=mode, outcome="timeout")
+            return f"[!] Python execution timed out after {timeout_seconds} seconds (container sandbox)"
+
+        output_parts: list[str] = []
+        if sandbox_result.stdout:
+            output_parts.append(sandbox_result.stdout)
+        if sandbox_result.stderr:
+            stderr_lines = [
+                line for line in sandbox_result.stderr.splitlines()
+                if "ImportError" not in line and "No module named" not in line
+            ]
+            if stderr_lines:
+                output_parts.append("[stderr]\n" + "\n".join(stderr_lines))
+
+        _write_python_audit(agent, purpose=purpose, code=code, mode=mode, outcome="success")
+        if not output_parts:
+            return f"{warning_prefix}[+] Python executed successfully with no output (container sandbox)"
+
+        output = "\n".join(output_parts)
+        for sig in ["[DONE]", "[COMPLETE]"]:
+            output = output.replace(sig, f"[BLOCKED_{sig[1:-1]}]")
+        display_output = output
+        if max_output_chars > 0 and len(display_output) > max_output_chars:
+            clip = max_output_chars // 2
+            display_output = display_output[:clip] + "\n...[truncated]...\n" + display_output[-clip:]
+        set_raw_tool_output_override(
+            agent, tool="python_execute", arguments=args,
+            output=f"[+] Python execution result ({mode}, container sandbox):\n{output}",
+        )
+        return f"{warning_prefix}[+] Python execution result ({mode}, container sandbox):\n{display_output}"
+
     tmp_path = ""
     try:
         with tempfile.NamedTemporaryFile(
             mode="w", suffix=".py", delete=False, encoding="utf-8"
         ) as f:
-            preamble = (
-                "import sys, json, re, os, base64, hashlib, itertools, collections, datetime, struct, binascii, textwrap\n"
-                "try:\n    import requests\nexcept ImportError:\n    pass\n"
-                "try:\n    from bs4 import BeautifulSoup\nexcept ImportError:\n    pass\n"
-                "try:\n    from Crypto.Cipher import AES\nexcept ImportError:\n    pass\n\n"
-            )
             f.write(preamble)
             f.write(code)
             tmp_path = f.name
 
         base_env = {"PYTHONIOENCODING": "utf-8"}
         env = {**{k: v for k, v in os.environ.items() if not k.startswith("VULNCLAW_")}, **base_env} if mode == "trusted-local" else base_env
+        preexec_fn = _resource_limit_preexec_fn(safety)
 
         loop = asyncio.get_running_loop()
         result = await loop.run_in_executor(
@@ -1907,6 +2151,7 @@ async def execute_python(agent: AgentContext, args: dict[str, Any]) -> str:
                 timeout=timeout_seconds,
                 cwd=tempfile.gettempdir(),
                 env=env,
+                preexec_fn=preexec_fn,
             ),
         )
 

--- a/vulnclaw/agent/builtin_tools.py
+++ b/vulnclaw/agent/builtin_tools.py
@@ -501,7 +501,6 @@ async def execute_shell_command(agent: AgentContext, args: dict[str, Any]) -> st
     max_output_chars = int(args.get("max_output_chars") or 0)
     shell_name = str(args.get("shell") or "")
     argv = _shell_argv(command, shell_name)
-    use_shell = os.name != "nt"
     env = {**os.environ, "PYTHONIOENCODING": "utf-8"}
     started = time.perf_counter()
     safety = getattr(agent.config, "safety", None)
@@ -545,14 +544,26 @@ async def execute_shell_command(agent: AgentContext, args: dict[str, Any]) -> st
             return raw_output[:clip] + "\n...[truncated by max_output_chars]...\n" + raw_output[-clip:]
         return raw_output
 
+    # Normalize to an explicit argv list even on POSIX (where `shell=True`
+    # would otherwise implicitly do this same `/bin/sh -c command` internally)
+    # so a cgroup wrapper (a real executable + its own args) can be prefixed
+    # in front of it -- `shell=True` and a systemd-run prefix don't compose.
+    if isinstance(argv, str):
+        base_argv: list[str] = ["/bin/sh", "-c", argv]
+    else:
+        base_argv = argv
+    from vulnclaw.agent.cgroup_exec import wrap_argv_for_cgroup
+
+    final_argv = wrap_argv_for_cgroup(base_argv, safety=safety, label="shell")
+
     try:
         loop = asyncio.get_running_loop()
         result = await loop.run_in_executor(
             None,
             lambda: subprocess.run(
-                argv,
+                final_argv,
                 cwd=str(workdir),
-                shell=use_shell,
+                shell=False,
                 capture_output=True,
                 text=True,
                 encoding="utf-8",
@@ -2138,12 +2149,15 @@ async def execute_python(agent: AgentContext, args: dict[str, Any]) -> str:
         base_env = {"PYTHONIOENCODING": "utf-8"}
         env = {**{k: v for k, v in os.environ.items() if not k.startswith("VULNCLAW_")}, **base_env} if mode == "trusted-local" else base_env
         preexec_fn = _resource_limit_preexec_fn(safety)
+        from vulnclaw.agent.cgroup_exec import wrap_argv_for_cgroup
+
+        final_argv = wrap_argv_for_cgroup([sys.executable, tmp_path], safety=safety, label="python")
 
         loop = asyncio.get_running_loop()
         result = await loop.run_in_executor(
             None,
             lambda: subprocess.run(
-                [sys.executable, tmp_path],
+                final_argv,
                 capture_output=True,
                 text=True,
                 encoding="utf-8",

--- a/vulnclaw/agent/cgroup_exec.py
+++ b/vulnclaw/agent/cgroup_exec.py
@@ -1,0 +1,144 @@
+"""Live-system-aware cgroup resource confinement for the direct-host execution path.
+
+Why this exists, and why it's a different mechanism from the POSIX rlimits
+already applied via `_resource_limit_preexec_fn` in builtin_tools.py:
+RLIMIT_AS/RLIMIT_CPU/RLIMIT_NOFILE bound what a *single process* may claim,
+but they are static numbers chosen in advance -- they know nothing about how
+much memory/CPU the *host* can actually spare right now. RLIMIT_NPROC turned
+out to be worse than static: it's a system-wide-per-UID counter on Linux, not
+scoped to the calling process's own subtree (see
+builtin_tools._current_uid_task_count's docstring for the concrete failure
+this caused -- a hardcoded cap of 16 broke a single benign
+`threading.Thread()` on a host already running ~220 processes for one user).
+
+cgroups v2, via a transient `systemd-run --user --scope` unit, fix both
+problems at once:
+  - MemoryMax/MemorySwapMax/CPUQuota/TasksMax are enforced by the kernel
+    against *this one cgroup only*. An OOM kill or CPU throttle here cannot
+    cascade into starving unrelated processes on the same host -- unlike a
+    raw RLIMIT_NPROC's system-wide accounting, TasksMax counts only tasks
+    inside this specific scope, so no "current count + headroom" workaround
+    is needed the way it was for the rlimit path.
+  - MemoryMax is sized dynamically against /proc/meminfo's MemAvailable at
+    call time, so the cap adapts to whatever the host can actually spare
+    *right now* instead of a number chosen once, in advance, that might
+    exceed currently-free memory on a busy day -- which is exactly what
+    would risk tipping the whole system into swapping/thrashing, the
+    concrete failure mode this module exists to prevent.
+  - CPUWeight is *proportional*, not absolute: under real contention this
+    workload automatically yields to other real work via the kernel's own
+    fair-share scheduler, instead of us trying to hand-guess "how busy is
+    the system right now" and hard-coding a threshold around that guess.
+
+Falls back to leaving argv unchanged if `systemd-run` isn't on PATH, cgroups
+v2 isn't mounted, or a live smoke test fails (e.g. no active `systemd --user`
+instance for this session) -- the POSIX rlimit preexec_fn in
+builtin_tools.py still applies underneath as a portable, if cruder, backstop
+on hosts where this path isn't available.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import uuid
+from pathlib import Path
+from typing import Any
+
+_SYSTEMD_RUN_CHECKED = False
+_SYSTEMD_RUN_AVAILABLE = False
+
+
+def systemd_cgroup_available(*, force_recheck: bool = False) -> bool:
+    """Cache a real smoke test, not just a binary/path existence check --
+    `systemd-run --user --scope` additionally needs a live user systemd
+    instance (an active login session with DBus), which a bare `which
+    systemd-run` cannot tell us about."""
+    global _SYSTEMD_RUN_CHECKED, _SYSTEMD_RUN_AVAILABLE
+    if _SYSTEMD_RUN_CHECKED and not force_recheck:
+        return _SYSTEMD_RUN_AVAILABLE
+    _SYSTEMD_RUN_CHECKED = True
+
+    if shutil.which("systemd-run") is None:
+        _SYSTEMD_RUN_AVAILABLE = False
+        return False
+    if not Path("/sys/fs/cgroup/cgroup.controllers").exists():
+        _SYSTEMD_RUN_AVAILABLE = False
+        return False
+
+    try:
+        probe = subprocess.run(
+            ["systemd-run", "--user", "--scope", "--quiet", "--collect", "--", "true"],
+            capture_output=True,
+            timeout=5,
+        )
+        _SYSTEMD_RUN_AVAILABLE = probe.returncode == 0
+    except (OSError, subprocess.TimeoutExpired):
+        _SYSTEMD_RUN_AVAILABLE = False
+    return _SYSTEMD_RUN_AVAILABLE
+
+
+def _read_available_memory_mb() -> int | None:
+    """Best-effort read of /proc/meminfo's MemAvailable, in MB."""
+    try:
+        with open("/proc/meminfo", encoding="utf-8") as f:
+            for line in f:
+                if line.startswith("MemAvailable:"):
+                    parts = line.split()
+                    if len(parts) >= 2:
+                        return int(parts[1]) // 1024
+    except (OSError, ValueError):
+        pass
+    return None
+
+
+def _dynamic_memory_cap_mb(configured_max_mb: int, safety: Any) -> int:
+    """Never let a call claim more than a safe fraction of what's *currently*
+    free on the host, even when the configured ceiling is higher -- that
+    ceiling is a maximum, not a promise that this much is actually free
+    today. Falls back to the static configured value if /proc/meminfo can't
+    be read (e.g. non-Linux)."""
+    fraction = float(getattr(safety, "resource_limit_dynamic_memory_fraction", 0.5) or 0.5)
+    floor_mb = int(getattr(safety, "resource_limit_min_memory_mb", 64) or 64)
+    available_mb = _read_available_memory_mb()
+    if available_mb is None:
+        return configured_max_mb
+    dynamic_ceiling = max(floor_mb, int(available_mb * fraction))
+    return min(configured_max_mb, dynamic_ceiling)
+
+
+def wrap_argv_for_cgroup(argv: list[str], *, safety: Any, label: str) -> list[str]:
+    """Prefix argv with a transient `systemd-run --user --scope` wrapper
+    carrying live-adjusted cgroup limits. Returns argv unchanged if the
+    cgroup path isn't usable on this host -- callers keep relying on the
+    POSIX rlimit preexec_fn underneath either way, this only adds a
+    stronger, host-aware layer on top when it's available."""
+    if safety is not None and not getattr(safety, "resource_limits_enabled", True):
+        return argv
+    if not systemd_cgroup_available():
+        return argv
+
+    memory_mb = max(
+        1,
+        _dynamic_memory_cap_mb(
+            int(getattr(safety, "resource_limit_max_memory_mb", 512) or 512), safety
+        ),
+    )
+    max_procs = int(getattr(safety, "resource_limit_max_processes", 32) or 32)
+    cpu_quota_pct = int(getattr(safety, "resource_limit_cpu_quota_percent", 100) or 100)
+    cpu_weight = int(getattr(safety, "resource_limit_cpu_weight", 50) or 50)
+    swap_mb = min(memory_mb, int(getattr(safety, "resource_limit_max_swap_mb", 128) or 128))
+    unit_name = f"vulnclaw-{label}-{uuid.uuid4().hex[:8]}"
+
+    return [
+        "systemd-run", "--user", "--scope", "--quiet", "--collect",
+        f"--unit={unit_name}",
+        "-p", "MemoryAccounting=yes",
+        "-p", f"MemoryMax={memory_mb}M",
+        "-p", f"MemorySwapMax={swap_mb}M",
+        "-p", f"CPUQuota={cpu_quota_pct}%",
+        "-p", f"CPUWeight={cpu_weight}",
+        "-p", f"TasksMax={max_procs}",
+        "--",
+        *argv,
+    ]

--- a/vulnclaw/agent/sandbox.py
+++ b/vulnclaw/agent/sandbox.py
@@ -1,0 +1,231 @@
+"""Opt-in Docker container execution backend for shell_command/python_execute.
+
+Why this exists: `execute_shell_command`/`execute_python` in builtin_tools.py
+run directly on the host by default — the only controls are static source
+checks (regex/AST, easily incomplete by construction in a Turing-complete
+language) and POSIX rlimits (CPU/memory/nproc/fd caps, which bound resource
+*consumption* but do not confine filesystem or network access). Real
+filesystem/network/capability confinement requires OS-level isolation, which
+on Linux means namespaces + cgroups — i.e. a container. This module is that
+backend: off by default (SafetyConfig.container_sandbox_mode == "off"), and
+opt-in per the SafetyConfig.container_sandbox_mode toggle in config/schema.py.
+
+Design choices, and why:
+- Disposable, `--rm` containers, one per call. No pooling/reuse: a reused
+  container is a container that can accumulate state/files across calls from
+  a target the model doesn't fully trust yet.
+- `--network none` by default (SafetyConfig.container_sandbox_network=True
+  opts back into `--network bridge` for tasks that genuinely need to reach
+  the target from inside the sandbox, e.g. python_execute doing its own HTTP
+  probing). This is the single highest-value containment property for a
+  pentest tool: even a fully-compromised or malicious code path inside the
+  sandbox cannot exfiltrate data or reach anything on the host network by
+  default.
+- `--read-only` rootfs + a size-capped tmpfs `/tmp` and a single writable
+  bind-mount (`/workspace`, the per-call scratch dir) — code cannot persist
+  or tamper with anything outside that one directory.
+- `--cap-drop=ALL --security-opt=no-new-privileges --user <uid>:<gid>` — no
+  Linux capabilities, no privilege escalation via setuid binaries, and never
+  runs as root inside the container even though the image's default user
+  might be root.
+- Docker's own cgroup-backed `--memory`/`--pids-limit` are used instead of
+  (or, harmlessly, in addition to) the POSIX rlimits in builtin_tools.py —
+  cgroup memory limits trigger the kernel OOM killer against the whole
+  container, which a process cannot catch or work around the way it might
+  retry past a plain rlimit.
+- If Docker is unavailable when a mode requires it, this raises rather than
+  silently falling back to unsandboxed host execution — a silent downgrade
+  would defeat the entire point of the user opting into container mode.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import shutil
+import subprocess
+import tempfile
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+class SandboxUnavailableError(RuntimeError):
+    """Raised when container_sandbox_mode requires Docker but it isn't usable."""
+
+
+@dataclass
+class SandboxResult:
+    ok: bool
+    stdout: str
+    stderr: str
+    exit_code: int | None
+    timed_out: bool
+    elapsed_ms: int
+    detail: str = ""
+
+
+_DOCKER_CHECKED: bool = False
+_DOCKER_AVAILABLE: bool = False
+
+
+def docker_available(*, force_recheck: bool = False) -> bool:
+    """Cache a cheap `docker version` probe; Docker daemon checks are not free."""
+    global _DOCKER_CHECKED, _DOCKER_AVAILABLE
+    if _DOCKER_CHECKED and not force_recheck:
+        return _DOCKER_AVAILABLE
+    _DOCKER_CHECKED = True
+    if shutil.which("docker") is None:
+        _DOCKER_AVAILABLE = False
+        return False
+    try:
+        proc = subprocess.run(
+            ["docker", "version", "--format", "{{.Server.Version}}"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        _DOCKER_AVAILABLE = proc.returncode == 0
+    except (OSError, subprocess.TimeoutExpired):
+        _DOCKER_AVAILABLE = False
+    return _DOCKER_AVAILABLE
+
+
+def _docker_base_args(safety: Any, *, memory_mb: int, pids_headroom: int) -> list[str]:
+    network_mode = "bridge" if getattr(safety, "container_sandbox_network", False) else "none"
+    uid = os.getuid() if hasattr(os, "getuid") else 1000
+    gid = os.getgid() if hasattr(os, "getgid") else 1000
+    return [
+        "docker", "run", "--rm",
+        "--network", network_mode,
+        "--cap-drop", "ALL",
+        "--security-opt", "no-new-privileges",
+        "--read-only",
+        "--tmpfs", "/tmp:rw,size=64m,mode=1777",
+        f"--memory={memory_mb}m",
+        f"--memory-swap={memory_mb}m",
+        f"--pids-limit={pids_headroom}",
+        "--user", f"{uid}:{gid}",
+    ]
+
+
+async def run_python_in_container(
+    code: str,
+    *,
+    safety: Any,
+    timeout_s: float,
+    preamble: str = "",
+) -> SandboxResult:
+    """Execute `code` inside a disposable, isolated container. Raises
+    SandboxUnavailableError if Docker isn't reachable — never silently falls
+    back to running unsandboxed on the host."""
+    if not docker_available():
+        raise SandboxUnavailableError(
+            "container_sandbox_mode requires Docker but the `docker` CLI/daemon "
+            "is not reachable. Either start Docker, or set "
+            "safety.container_sandbox_mode back to 'off' to run on the host "
+            "directly (loses the network/filesystem isolation this mode provides)."
+        )
+
+    image = getattr(safety, "container_sandbox_image", "python:3.13-slim")
+    memory_mb = int(getattr(safety, "container_sandbox_memory_mb", 512) or 512)
+    pids_headroom = int(getattr(safety, "resource_limit_max_processes", 32) or 32)
+
+    with tempfile.TemporaryDirectory(prefix="vulnclaw-sandbox-") as scratch:
+        script_path = Path(scratch) / "script.py"
+        script_path.write_text(preamble + code, encoding="utf-8")
+        os.chmod(scratch, 0o777)  # container runs as host uid:gid, needs to read its own mount
+
+        args = _docker_base_args(safety, memory_mb=memory_mb, pids_headroom=pids_headroom)
+        args += ["-v", f"{scratch}:/workspace:ro", "-w", "/workspace", image, "python", "/workspace/script.py"]
+
+        started = time.perf_counter()
+        try:
+            loop = asyncio.get_running_loop()
+            proc = await loop.run_in_executor(
+                None,
+                lambda: subprocess.run(args, capture_output=True, text=True, timeout=timeout_s),
+            )
+            elapsed_ms = int((time.perf_counter() - started) * 1000)
+            return SandboxResult(
+                ok=proc.returncode == 0,
+                stdout=proc.stdout,
+                stderr=proc.stderr,
+                exit_code=proc.returncode,
+                timed_out=False,
+                elapsed_ms=elapsed_ms,
+            )
+        except subprocess.TimeoutExpired as exc:
+            elapsed_ms = int((time.perf_counter() - started) * 1000)
+            return SandboxResult(
+                ok=False,
+                stdout=str(exc.stdout or ""),
+                stderr=str(exc.stderr or ""),
+                exit_code=None,
+                timed_out=True,
+                elapsed_ms=elapsed_ms,
+                detail=f"container timed out after {timeout_s:.0f}s",
+            )
+
+
+async def run_shell_in_container(
+    command: str,
+    *,
+    safety: Any,
+    timeout_s: float,
+    workdir: str | None = None,
+) -> SandboxResult:
+    """Execute a shell command inside a disposable, isolated container."""
+    if not docker_available():
+        raise SandboxUnavailableError(
+            "container_sandbox_mode requires Docker but the `docker` CLI/daemon "
+            "is not reachable. Either start Docker, or set "
+            "safety.container_sandbox_mode back to 'off' to run on the host "
+            "directly (loses the network/filesystem isolation this mode provides)."
+        )
+
+    image = getattr(safety, "container_sandbox_image", "python:3.13-slim")
+    memory_mb = int(getattr(safety, "container_sandbox_memory_mb", 512) or 512)
+    pids_headroom = int(getattr(safety, "resource_limit_max_processes", 32) or 32)
+
+    # A read-only bind mount of the caller's workdir (if any) — the sandboxed
+    # command can read files there for context (e.g. inspecting downloaded
+    # source) but cannot write back into the host filesystem outside /tmp.
+    mount_args: list[str] = []
+    effective_workdir = "/workspace"
+    if workdir and Path(workdir).is_dir():
+        mount_args = ["-v", f"{workdir}:/workspace:ro"]
+    else:
+        effective_workdir = "/tmp"
+
+    args = _docker_base_args(safety, memory_mb=memory_mb, pids_headroom=pids_headroom)
+    args += mount_args + ["-w", effective_workdir, image, "sh", "-c", command]
+
+    started = time.perf_counter()
+    try:
+        loop = asyncio.get_running_loop()
+        proc = await loop.run_in_executor(
+            None,
+            lambda: subprocess.run(args, capture_output=True, text=True, timeout=timeout_s),
+        )
+        elapsed_ms = int((time.perf_counter() - started) * 1000)
+        return SandboxResult(
+            ok=proc.returncode == 0,
+            stdout=proc.stdout,
+            stderr=proc.stderr,
+            exit_code=proc.returncode,
+            timed_out=False,
+            elapsed_ms=elapsed_ms,
+        )
+    except subprocess.TimeoutExpired as exc:
+        elapsed_ms = int((time.perf_counter() - started) * 1000)
+        return SandboxResult(
+            ok=False,
+            stdout=str(exc.stdout or ""),
+            stderr=str(exc.stderr or ""),
+            exit_code=None,
+            timed_out=True,
+            elapsed_ms=elapsed_ms,
+            detail=f"container timed out after {timeout_s:.0f}s",
+        )

--- a/vulnclaw/config/schema.py
+++ b/vulnclaw/config/schema.py
@@ -339,6 +339,47 @@ class SafetyConfig(BaseModel):
         description="RLIMIT_NOFILE: max open file descriptors for the child",
     )
 
+    # ── cgroups v2 (systemd-run --user --scope), live-system-aware ──────
+    # A second, stronger confinement layer on the direct-host execution path
+    # (see agent/cgroup_exec.py for the full rationale). Unlike the POSIX
+    # rlimits above, these limits are enforced per-cgroup by the kernel (no
+    # RLIMIT_NPROC-style system-wide-per-UID surprise) and the memory ceiling
+    # is computed against /proc/meminfo's MemAvailable *at call time* — the
+    # whole point being that a call can never be assigned more memory than
+    # the host can actually spare right now, which is what actually prevents
+    # the host from being pushed into swapping/thrashing. Auto-detected and
+    # skipped (falls back to the rlimit-only path) when systemd-run/cgroups
+    # v2 aren't usable on this host — never a hard requirement.
+    resource_limit_dynamic_memory_fraction: float = Field(
+        default=0.5,
+        description=(
+            "Max fraction of *currently available* host memory (from /proc/meminfo's "
+            "MemAvailable, read fresh at call time) a single call may be granted, even if "
+            "resource_limit_max_memory_mb is configured higher. This is what keeps the cap "
+            "honest on a busy host instead of a number chosen once, in advance."
+        ),
+    )
+    resource_limit_min_memory_mb: int = Field(
+        default=64,
+        description="Floor for the dynamic memory cap, so trivial scripts still get a workable minimum",
+    )
+    resource_limit_max_swap_mb: int = Field(
+        default=128,
+        description="MemorySwapMax for the cgroup scope — kept low so a runaway call is OOM-killed "
+        "promptly inside its own cgroup rather than slowly swap-thrashing the whole host",
+    )
+    resource_limit_cpu_quota_percent: int = Field(
+        default=100,
+        description="CPUQuota for the cgroup scope, as % of one core — an absolute ceiling even when "
+        "the host is otherwise idle",
+    )
+    resource_limit_cpu_weight: int = Field(
+        default=50,
+        description="CPUWeight for the cgroup scope (systemd default is 100) — set below default so "
+        "this workload proportionally yields to other real work under contention, adapting "
+        "automatically instead of us guessing a load threshold",
+    )
+
     # ── Opt-in container sandbox ─────────────────────────────────────────
     # When enabled (and Docker is reachable), routes python_execute and/or
     # shell_command through a disposable, network-isolated, capability-

--- a/vulnclaw/config/schema.py
+++ b/vulnclaw/config/schema.py
@@ -302,6 +302,70 @@ class SafetyConfig(BaseModel):
         description="Max number of tool calls executed concurrently per round (1=serial)",
     )
 
+    # ── Kernel-enforced resource limits (POSIX rlimits) ─────────────────
+    # Applied to every shell_command/python_execute child process regardless
+    # of python_execute_mode. Source-pattern checks (BLOCKED_PATTERNS, the AST
+    # bypass checker) can never be a complete defense in a Turing-complete
+    # language — these limits are the backstop: even code that slips past
+    # static analysis is still capped by the kernel on CPU time, address
+    # space, process count (fork-bomb protection), and open file descriptors.
+    # No-op on non-POSIX platforms (the `resource` module is Unix-only).
+    resource_limits_enabled: bool = Field(
+        default=True,
+        description=(
+            "Enforce POSIX rlimits (CPU/memory/process-count/fd caps) on every "
+            "shell_command/python_execute child process. No-op on Windows."
+        ),
+    )
+    resource_limit_max_cpu_seconds: int = Field(
+        default=30,
+        description="RLIMIT_CPU: max CPU seconds a shell_command/python_execute child may consume",
+    )
+    resource_limit_max_memory_mb: int = Field(
+        default=512,
+        description="RLIMIT_AS: max address space (MB) a shell_command/python_execute child may map",
+    )
+    resource_limit_max_processes: int = Field(
+        default=32,
+        description=(
+            "RLIMIT_NPROC headroom: how many NEW processes/threads this call may add on top "
+            "of whatever the user's other sessions already have running (fork-bomb cap). "
+            "Not an absolute ceiling — RLIMIT_NPROC is enforced per-UID system-wide on Linux, "
+            "so an absolute cap would fail on a busy host even for one benign thread."
+        ),
+    )
+    resource_limit_max_open_files: int = Field(
+        default=256,
+        description="RLIMIT_NOFILE: max open file descriptors for the child",
+    )
+
+    # ── Opt-in container sandbox ─────────────────────────────────────────
+    # When enabled (and Docker is reachable), routes python_execute and/or
+    # shell_command through a disposable, network-isolated, capability-
+    # dropped container instead of running directly on the host. Off by
+    # default: it changes tool behavior (host CLI tools like nmap/sqlmap are
+    # not present in the sandbox image unless the user supplies one) so it
+    # must be an explicit choice, not a silent default.
+    container_sandbox_mode: str = Field(
+        default="off",
+        description=(
+            "Container isolation for dangerous tools: off, python_execute, "
+            "shell_command, or all. Requires Docker reachable on the host."
+        ),
+    )
+    container_sandbox_image: str = Field(
+        default="python:3.13-slim",
+        description="Docker image used for the container sandbox execution backend",
+    )
+    container_sandbox_network: bool = Field(
+        default=False,
+        description="Allow the sandbox container outbound network access (default: none)",
+    )
+    container_sandbox_memory_mb: int = Field(
+        default=512,
+        description="Memory limit (MB) passed to `docker run --memory` for the sandbox container",
+    )
+
 
 class SessionConfig(BaseModel):
     """Session / output configuration."""


### PR DESCRIPTION
## Motivation

`python_execute` and `shell_command` run arbitrary code/commands directly on the host. The only controls today are static source checks and a wall-clock timeout — no resource caps, no filesystem/network confinement. Three independent, concrete gaps found by inspection and confirmed with live reproductions:

## 1. The blocklist only catches `subprocess.Popen(`

`BLOCKED_PATTERNS` (applied in **every** `python_execute_mode`, including the default `trusted-local`, where `SAFE_MODE_PATTERNS`/`LAB_MODE_PATTERNS` don't apply at all) only matches `subprocess.Popen(`. Every other process-spawning entry point sails through untouched:

```python
import subprocess
subprocess.run(['id'])          # not blocked before this PR
```
```python
import os
os.popen('id').read()           # not blocked before this PR
```
```python
from subprocess import run
run(['id'])                     # not blocked before this PR -- regex can't see this form at all
```

Fixed by enumerating `(module, dangerous_attribute)` pairs in the AST checker instead of growing an ad-hoc regex list per call spelling — this also correctly tracks aliased imports (`import subprocess as sp`) and `from X import Y` forms, which regex structurally cannot. Also filled the equivalent gaps in the regex fast-path for cheap early rejection.

Verified: all three bypasses above are now blocked with a clear reason string; benign code (`print(2+2)`, a bare `threading.Thread()`) still runs unaffected.

## 2. No resource limits beyond a wall-clock timeout

Added POSIX rlimits (`RLIMIT_CPU`, `RLIMIT_AS`, `RLIMIT_NPROC`, `RLIMIT_NOFILE`) via `preexec_fn` on every child process spawned by either tool — kernel-enforced, so it holds regardless of what the child actually executes (a real backstop under the necessarily-incomplete static checks above; you cannot enumerate every way to consume unbounded memory/CPU in a Turing-complete language).

**Caught a real bug in my own first pass, worth flagging explicitly**: `RLIMIT_NPROC` is enforced by Linux as a **system-wide-per-UID** count, not scoped to the calling process's own subtree. An absolute cap of 16 made a single benign `threading.Thread()` fail with `RuntimeError: can't start new thread` on any host that already runs many unrelated processes under the same user (reproduced on a dev box already running ~220 processes/threads for one UID — a completely ordinary desktop, not an edge case). Fixed by reading the current live count from `/proc` at call time and sizing the new limit as headroom above it, not an absolute ceiling. No-op on non-POSIX platforms.

## 3. No real filesystem/network isolation

Static analysis and rlimits bound *what patterns are allowed* and *how much a process may consume* — neither confines *what it can reach*. Added an opt-in Docker-backed execution backend (`agent/sandbox.py`), gated by a new `safety.container_sandbox_mode` config (`off` / `python_execute` / `shell_command` / `all`, **default `off`** — this changes tool capability, e.g. host-installed recon tools aren't present in the sandbox image, so it must be a deliberate opt-in, not a silent default):

- Disposable `--rm` container per call — no state/files persist across calls.
- `--network none` by default (`container_sandbox_network=true` opts back into `bridge` for tasks that need to reach the target from inside the sandbox).
- `--read-only` rootfs + size-capped tmpfs `/tmp` + one read-only bind mount for the actual payload/workdir.
- `--cap-drop=ALL --security-opt=no-new-privileges --user <uid>:<gid>` — no Linux capabilities, no privilege escalation, never root even if the image's default user is root.
- Docker's own cgroup `--memory`/`--pids-limit` (in addition to, not instead of, the rlimits above — a cgroup OOM kill can't be caught/retried around the way a plain rlimit sometimes can).
- **Fails closed**: if Docker isn't reachable when a mode requires it, raises a clear error — never silently falls back to unsandboxed host execution, which would defeat the entire point of opting in.

## Verification (live, not simulated)

- Benign python + shell commands run correctly inside the sandbox.
- Network isolation: a request from inside the sandbox to the host's own Docker bridge IP fails with `Network is unreachable` — confirmed unreachable, not just untried.
- Filesystem isolation: code inside the sandbox reads its **own container's** `/etc/hostname` (a random container ID), not the host's.
- Privilege drop: `id` inside the sandboxed shell reports `uid=1000 gid=1000`, not root, even though the base image's default user is root.
- Fail-closed: monkeypatched Docker-unavailable path returns the intended error string, confirmed no fallback execution occurs.
- All three layers retested together against `python_execute_mode` safe/lab/trusted-local — no regressions.