### PR TITLE
docs: correct Burp MCP prerequisite -- Community Edition works for capture/replay

### DIFF
--- a/docs/mcp-deployment.md
+++ b/docs/mcp-deployment.md
@@ -105,8 +105,20 @@ https://github.com/PortSwigger/mcp-server
 ### 前置条件
 
 - Java（PATH 中可用，`java --version` 验证）
-- Burp Suite Professional（Community 版功能有限）
+- Burp Suite（Community 或 Professional 均可 —— 见下方说明）
 - `jar` 命令可用
+
+> **Community vs Professional**：实测（对照 PortSwigger/mcp-server 源码
+> `Tools.kt`）该扩展仅有一个工具受 Edition 限制——`get_proxy_issues`
+> （`api.burpSuite().version().edition() == PROFESSIONAL` 时才注册，对应
+> Burp Scanner，Community 版本身就没有 Scanner）。抓包/重放/拦截相关的
+> 全部工具（`send_http1_request`、`send_http2_request`、
+> `create_repeater_tab`、`send_to_intruder`、`get_proxy_http_history` 等）
+> 与 Edition 无关，在 Community 版上同样可用。已在 Kali 自带的 Burp Suite
+> Community Edition 上端到端验证：加载扩展、启用 MCP、通过 SSE 发送真实
+> HTTP 请求并在 Burp 自己的 Logger 中确认该请求确实经过了 Burp 的引擎。
+> 因此本文档一直标注的“Community 版功能有限”对本节描述的抓包/重放场景
+> 并不成立——只有想用 Burp Scanner 才需要 Professional。
 
 ### 安装步骤
 


### PR DESCRIPTION
The prerequisite section states "Burp Suite Professional (Community 版功能有限)" without qualifying which features actually need Pro — reads like the whole Burp MCP integration needs a paid license.

Checked against PortSwigger/mcp-server's own source (`Tools.kt`): exactly one tool is gated on edition —

```kotlin
if (api.burpSuite().version().edition() == BurpSuiteEdition.PROFESSIONAL) {
    mcpPaginatedTool<GetScannerIssues>(...)
}
```

`get_proxy_issues`/Scanner, which Community doesn't have at all regardless of this extension. Every capture/replay/intercept tool this doc section is actually about (`send_http1_request`, `send_http2_request`, `create_repeater_tab`, `send_to_intruder`, `get_proxy_http_history`, etc.) is edition-agnostic.

Verified end-to-end on Kali's stock Burp Suite Community Edition (2026.3.2): built `burp-mcp-all.jar`, loaded it as an extension, enabled the MCP tab, and sent a real HTTP request through VulnClaw → Burp's SSE MCP server → Burp's own HTTP engine → target — confirmed in Burp's own Logger with a matching host/path/200 status. No Pro license involved anywhere in that path.