### PR TITLE
security: hard SSRF denylist for cloud metadata + close scope gaps in chat mode and chrome-devtools

### DIFF
--- a/vulnclaw/agent/builtin_tools.py
+++ b/vulnclaw/agent/builtin_tools.py
@@ -53,6 +53,7 @@ from vulnclaw.config.source_render import (
 # 修改原因: 消除 V1 违规 — infer_port_from_url 已移至 config/url_utils.py，
 #          此处重新导出以保持向后兼容。
 from vulnclaw.config.url_utils import infer_port_from_url  # noqa: F401 — re-export
+from vulnclaw.config.url_utils import is_cloud_metadata_address
 from vulnclaw.intel.tools import (
     INTEL_TOOL_NAMES,
     dispatch_intel_tool,
@@ -1040,7 +1041,22 @@ def enforce_port_constraints(agent: AgentContext, ports: list[int], *, target: s
 def enforce_host_path_constraints(
     agent: AgentContext, *, host: str = "", path: str = "", target: str = ""
 ) -> str | None:
-    """Return a user-facing violation when host/path are out of scope."""
+    """Return a user-facing violation when host/path are out of scope.
+
+    Checks the cloud-metadata hard denylist unconditionally, before the
+    optional scope allowlist below and regardless of whether any
+    TaskConstraints scope is configured -- an empty/unset scope must not mean
+    "anything goes" for these specific addresses. See url_utils.py for why
+    this is a narrow, always-on floor rather than blocking all of RFC1918.
+    """
+    if host:
+        is_metadata, reason = is_cloud_metadata_address(host)
+        if is_metadata:
+            return (
+                f"[constraint_violation] Host {host} is blocked: {reason}. "
+                "Cloud metadata endpoints are never a legitimate pentest target."
+            )
+
     session = getattr(agent, "session_state", None)
     constraints = getattr(session, "task_constraints", None)
     if constraints is None or constraints.is_empty():

--- a/vulnclaw/agent/core.py
+++ b/vulnclaw/agent/core.py
@@ -470,8 +470,22 @@ class AgentCore:
         """
         result = AgentResult()
 
-        # Chat mode is free-form — don't inherit constraints from previous sessions
-        self.context.state.task_constraints = TaskConstraints()
+        # Chat mode is free-form — don't inherit constraints from a previous,
+        # unrelated chat turn. That used to mean an *always-empty* scope for
+        # every chat message regardless of content, though, which is exactly
+        # what enforce_host_path_constraints/_check_fetch_constraints treat
+        # as "no restriction at all" -- so fetch/browse/python_execute's
+        # embedded-URL checks had zero scope enforcement in the tool's single
+        # most common interaction mode. Derive fresh constraints from what
+        # *this* message actually says instead: if it names a target/URL,
+        # extract_task_constraints (the same parser structured commands use)
+        # picks it up and scope enforcement applies; if it genuinely names no
+        # target (a bare "what does SSRF mean" Q&A), constraints stay empty,
+        # same as before -- this only tightens the common case where a target
+        # actually is mentioned, never a message that mentions none.
+        self.context.state.task_constraints = (
+            extract_task_constraints(user_input) if user_input else TaskConstraints()
+        )
 
         # Detect target and phase from input
         detected_target = target or self._detect_target(user_input)

--- a/vulnclaw/config/url_utils.py
+++ b/vulnclaw/config/url_utils.py
@@ -9,7 +9,51 @@
 
 from __future__ import annotations
 
+import socket
 from urllib.parse import urlparse
+
+# 修改者: security-hardening pass (SSRF gap closure)
+# 修改原因: enforce_host_path_constraints / _check_fetch_constraints both
+# return "allowed" unconditionally whenever no TaskConstraints scope is set
+# (constraints.is_empty()) -- which is the *default* state for chat/repl mode
+# by explicit design (see agent/core.py's "Chat mode is free-form" comment).
+# That means fetch/python_execute/shell_command/chrome-devtools had zero
+# built-in protection against being pointed at cloud metadata endpoints,
+# regardless of whether any scope was ever declared. This is a small,
+# always-on floor sitting *underneath* the optional scope allowlist: unlike
+# RFC1918 private ranges (which are legitimate targets for an authorized
+# internal pentest and must stay allowed when in-scope), these specific
+# addresses have essentially no legitimate reason to ever be a pentest
+# target, so they are hard-blocked unconditionally rather than only when a
+# scope happens to be configured.
+_HARD_BLOCKED_HOSTS = frozenset({
+    "169.254.169.254",   # AWS / GCP / DigitalOcean / OpenStack metadata
+    "169.254.170.2",     # AWS ECS task metadata
+    "metadata.google.internal",
+    "metadata.google",
+    "fd00:ec2::254",     # AWS IMDSv2, IPv6
+})
+
+
+def is_cloud_metadata_address(host: str) -> tuple[bool, str]:
+    """Return (True, reason) if `host` is a well-known cloud metadata
+    endpoint -- checked by literal hostname/IP and, best-effort, by DNS
+    resolution (so a domain that merely *resolves* to 169.254.169.254 is
+    caught too, not just the literal IP)."""
+    if not host:
+        return False, ""
+
+    candidate = host.strip().lower().rstrip(".")
+    if candidate in _HARD_BLOCKED_HOSTS:
+        return True, f"well-known cloud metadata endpoint ({candidate})"
+
+    try:
+        resolved = socket.gethostbyname(candidate)
+    except (socket.gaierror, socket.timeout, OSError):
+        return False, ""
+    if resolved in _HARD_BLOCKED_HOSTS:
+        return True, f"resolves to cloud metadata endpoint {resolved}"
+    return False, ""
 
 
 def infer_port_from_url(url: str) -> int | None:

--- a/vulnclaw/mcp/lifecycle.py
+++ b/vulnclaw/mcp/lifecycle.py
@@ -19,7 +19,7 @@ from vulnclaw.config.source_render import render_highlighted_source_block
 # 修改时间: 2026-07-08
 # 修改原因: 消除 V1 违规 — mcp/ 基础设施层不应反向依赖 agent/ 领域层，
 #          改为从 config/url_utils.py 导入纯 URL 工具函数。
-from vulnclaw.config.url_utils import infer_port_from_url
+from vulnclaw.config.url_utils import infer_port_from_url, is_cloud_metadata_address
 from vulnclaw.mcp._probe_mixin import ProbeMixin
 from vulnclaw.mcp.registry import HealthStatus, MCPRegistry
 
@@ -136,10 +136,6 @@ class MCPLifecycleManager(ProbeMixin):
         self._task_constraints = constraints
 
     def _check_fetch_constraints(self, arguments: dict[str, Any]) -> dict[str, Any] | None:
-        constraints = self._task_constraints
-        if constraints is None or constraints.is_empty():
-            return None
-
         url = str(arguments.get("url", "") or "").strip()
         if not url:
             return None
@@ -150,6 +146,28 @@ class MCPLifecycleManager(ProbeMixin):
             parsed = None
         host = parsed.hostname.lower() if parsed and parsed.hostname else ""
         path = parsed.path.rstrip("/") if parsed and parsed.path else ""
+
+        # Hard, always-on floor -- checked regardless of whether any
+        # TaskConstraints scope is set. See url_utils.is_cloud_metadata_address
+        # for why this is narrow (specific metadata endpoints) rather than a
+        # blanket block on private ranges, which are legitimate in-scope
+        # targets for an authorized internal pentest.
+        if host:
+            is_metadata, reason = is_cloud_metadata_address(host)
+            if is_metadata:
+                return self._tool_result(
+                    ok=False,
+                    server="fetch",
+                    tool="fetch",
+                    execution_mode="local",
+                    error_type="constraint_violation",
+                    message=f"Host {host} is blocked: {reason}.",
+                    suggestion="Cloud metadata endpoints are never a legitimate pentest target.",
+                )
+
+        constraints = self._task_constraints
+        if constraints is None or constraints.is_empty():
+            return None
 
         port = infer_port_from_url(url)
         if port is None:
@@ -224,6 +242,88 @@ class MCPLifecycleManager(ProbeMixin):
                 suggestion="Remove the blocked port from the request or adjust constraints.",
             )
 
+        return None
+
+    def _check_chrome_constraints(
+        self, tool_name: str, arguments: dict[str, Any]
+    ) -> dict[str, Any] | None:
+        """Gate browser navigation the same way _check_fetch_constraints gates
+        fetch -- chrome-devtools tool calls had NO scope/SSRF check at all
+        before this (found while auditing the tool's real network-touching
+        surface). Only navigate_page carries a fresh URL; every other chrome
+        tool (click, evaluate_script, take_screenshot, ...) operates on a
+        page the browser already navigated to, so gating navigation is what
+        actually matters here."""
+        url = str(arguments.get("url", "") or "").strip()
+        if not url:
+            return None
+
+        try:
+            parsed = urlparse(url)
+        except Exception:
+            parsed = None
+        host = parsed.hostname.lower() if parsed and parsed.hostname else ""
+        path = parsed.path.rstrip("/") if parsed and parsed.path else ""
+
+        if host:
+            is_metadata, reason = is_cloud_metadata_address(host)
+            if is_metadata:
+                return self._tool_result(
+                    ok=False,
+                    server="chrome-devtools",
+                    tool=tool_name,
+                    execution_mode="sdk",
+                    error_type="constraint_violation",
+                    message=f"Host {host} is blocked: {reason}.",
+                    suggestion="Cloud metadata endpoints are never a legitimate pentest target.",
+                )
+
+        constraints = self._task_constraints
+        if constraints is None or constraints.is_empty():
+            return None
+
+        if constraints.allowed_hosts and host and host not in constraints.allowed_hosts:
+            allowed_hosts = ", ".join(constraints.allowed_hosts)
+            return self._tool_result(
+                ok=False,
+                server="chrome-devtools",
+                tool=tool_name,
+                execution_mode="sdk",
+                error_type="constraint_violation",
+                message=f"Host {host} is outside allowed scope [{allowed_hosts}] for url {url}",
+                suggestion="Adjust the task scope or navigate to an allowed host.",
+            )
+        if host and host in constraints.blocked_hosts:
+            return self._tool_result(
+                ok=False,
+                server="chrome-devtools",
+                tool=tool_name,
+                execution_mode="sdk",
+                error_type="constraint_violation",
+                message=f"Host {host} is blocked by task constraints for url {url}",
+                suggestion="Remove the blocked host from the request or adjust constraints.",
+            )
+        if constraints.allowed_paths and path and path not in constraints.allowed_paths:
+            allowed_paths = ", ".join(constraints.allowed_paths)
+            return self._tool_result(
+                ok=False,
+                server="chrome-devtools",
+                tool=tool_name,
+                execution_mode="sdk",
+                error_type="constraint_violation",
+                message=f"Path {path} is outside allowed scope [{allowed_paths}] for url {url}",
+                suggestion="Adjust the task scope or navigate to an allowed path.",
+            )
+        if path and path in constraints.blocked_paths:
+            return self._tool_result(
+                ok=False,
+                server="chrome-devtools",
+                tool=tool_name,
+                execution_mode="sdk",
+                error_type="constraint_violation",
+                message=f"Path {path} is blocked by task constraints for url {url}",
+                suggestion="Remove the blocked path from the request or adjust constraints.",
+            )
         return None
 
     def _tool_result(
@@ -1305,6 +1405,10 @@ class MCPLifecycleManager(ProbeMixin):
                     structured_content=None,
                 )
             if server_name == "chrome-devtools":
+                violation = self._check_chrome_constraints(tool_name, arguments)
+                if violation is not None:
+                    self.registry.record_tool_call(server_name, success=False)
+                    return violation
                 try:
                     content, structured = await self._call_chrome(tool_name, arguments)
                     self.registry.record_tool_call(server_name, success=True)


### PR DESCRIPTION
## Three related gaps, found by tracing every network-touching tool's actual scope-check code path

### 1. Chat/repl mode had zero scope enforcement, by explicit design

`enforce_host_path_constraints` / `_check_fetch_constraints` both return "allowed" unconditionally whenever `constraints.is_empty()`. That's the *default* state for chat mode: `agent/core.py`'s message handler reset `task_constraints` to an always-empty `TaskConstraints()` on every chat turn, with a comment explaining chat is deliberately free-form. In the tool's single most common interaction mode, `fetch`/`python_execute`/`shell_command`'s embedded-URL checks and browser navigation had **no scope enforcement at all**, regardless of what target the user actually named in their message.

Fixed by deriving constraints from the message's own content (`extract_task_constraints(user_input)` — the same parser structured commands like `recon <target> --only-host X` already use) instead of always resetting to empty. A message that genuinely names no target still gets empty constraints (unchanged behavior for pure Q&A); this only tightens the common case where a target actually is mentioned.

### 2. No hard block on cloud metadata endpoints, even with a scope configured

`RESERVED_IP_RANGES`/`is_reserved_ip` exist but are only used as an informational warning on `nmap` scan targets — never enforced on `fetch`/`chrome-devtools`/`python_execute`'s embedded URLs. Added `url_utils.is_cloud_metadata_address()`: a small, always-on floor checked *unconditionally*, before and regardless of any `TaskConstraints` scope. Deliberately narrow — specific metadata addresses (`169.254.169.254`, `169.254.170.2`, `metadata.google.internal`, the AWS IMDSv2 IPv6 address), not a blanket RFC1918 block, since private ranges are legitimate targets for an authorized internal pentest and must stay allowed when in-scope.

### 3. chrome-devtools had no scope/SSRF gate of any kind

`fetch` calls went through `_check_fetch_constraints`; `chrome-devtools` calls (`navigate_page`, etc.) went straight to `_call_chrome` with no check at all. Added `_check_chrome_constraints`, wired into `_dispatch_call_tool` the same way `fetch` already was.

## Verification (live, not simulated)

- `extract_task_constraints("please look at http://127.0.0.1:3000 for me")` → `allowed_hosts: ['127.0.0.1']`; `extract_task_constraints("what does SSRF mean?")` → still empty (no false positive on target-less messages).
- `fetch` to `169.254.169.254` and to `metadata.google.internal` both blocked with a clear `constraint_violation`, even with zero scope configured.
- `fetch` and `navigate_page` to the real, authorized target both still succeed unaffected.
- `navigate_page` to `169.254.169.254` blocked — previously this had no gate whatsoever.