### PR TITLE
feat: real USD cost ceiling for a session, independent of solve_max_steps

### DIFF
--- a/vulnclaw/agent/core.py
+++ b/vulnclaw/agent/core.py
@@ -80,6 +80,12 @@ class AgentCore:
         # Failover key pool: prefer llm.api_keys, else the single llm.api_key.
         self._key_pool = config.llm.key_pool()
         self._key_index = 0
+        # Cumulative estimated USD spend for the lifetime of this AgentCore
+        # instance (i.e. one CLI process/session) -- see cost_budget.py.
+        # Deliberately NOT reset by apply_config or _reset_runtime_state: a
+        # config reload or a fresh chat turn mid-session must not zero out
+        # money already spent.
+        self.session_cost_usd: float = 0.0
         self.runtime = RuntimeState()
         self._reset_runtime_state()
         # Optional KB retriever — lazily initialized on first use

--- a/vulnclaw/agent/cost_budget.py
+++ b/vulnclaw/agent/cost_budget.py
@@ -1,0 +1,112 @@
+"""Real dollar-cost budget for LLM usage, independent of solve_max_steps.
+
+Why this exists: `session.solve_max_steps` (default 240) bounds how many
+autonomous tool-calling rounds a solve loop may run, but says nothing about
+what those rounds actually cost. 240 rounds of short, cheap completions and
+240 rounds of `reasoning_effort: high` on an expensive model are very
+different dollar amounts, and nothing before this stopped the latter. This
+module tracks an approximate running cost in USD, independent of step count,
+and lets a session hard-stop when a configured ceiling is hit.
+
+Deliberately approximate, not a billing reconciliation tool: pricing changes,
+providers differ, and this only needs to be close enough to catch a runaway
+loop before it burns real money -- not to the cent.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# Approximate USD price per 1M tokens: (input, output). Matched by substring
+# against the configured model name (case-insensitive), so "gpt-4o-mini-2024"
+# still matches "gpt-4o-mini". Unlisted models fall back to
+# _DEFAULT_PRICE_PER_MILLION_USD, a deliberately mid/high estimate so the cap
+# still means something for a model we don't recognize, rather than silently
+# under-counting it as free.
+_PRICING_PER_MILLION_USD: dict[str, tuple[float, float]] = {
+    "gpt-4o-mini": (0.15, 0.60),
+    "gpt-4o": (2.50, 10.00),
+    "gpt-5.5": (3.00, 15.00),
+    "gpt-5": (2.50, 10.00),
+    "o4-mini": (1.10, 4.40),
+    "o3": (2.00, 8.00),
+    "claude-opus": (15.00, 75.00),
+    "claude-sonnet": (3.00, 15.00),
+    "claude-haiku": (0.80, 4.00),
+    "deepseek-reasoner": (0.55, 2.19),
+    "deepseek-chat": (0.27, 1.10),
+    "deepseek": (0.27, 1.10),
+    "glm-4": (0.50, 0.50),
+    "qwen": (0.50, 2.00),
+    "kimi": (0.60, 2.50),
+}
+_DEFAULT_PRICE_PER_MILLION_USD = (3.00, 15.00)
+
+
+class SessionCostExceeded(RuntimeError):
+    """Raised when a new LLM call would run (or already has run) past the
+    configured session cost ceiling."""
+
+    def __init__(self, spent_usd: float, limit_usd: float):
+        self.spent_usd = spent_usd
+        self.limit_usd = limit_usd
+        super().__init__(
+            f"Session cost budget exceeded: ${spent_usd:.4f} spent > ${limit_usd:.2f} limit"
+        )
+
+
+def _lookup_price_per_million(model: str) -> tuple[float, float]:
+    model_lower = (model or "").strip().lower()
+    for key, price in _PRICING_PER_MILLION_USD.items():
+        if key in model_lower:
+            return price
+    return _DEFAULT_PRICE_PER_MILLION_USD
+
+
+def estimate_cost_usd(model: str, input_tokens: int, output_tokens: int) -> float:
+    """Approximate USD cost for one LLM call given its token usage."""
+    in_price, out_price = _lookup_price_per_million(model)
+    return (max(0, input_tokens) * in_price + max(0, output_tokens) * out_price) / 1_000_000.0
+
+
+def extract_usage_tokens(response: Any) -> tuple[int, int]:
+    """Best-effort (input_tokens, output_tokens) extraction from an
+    OpenAI-compatible completion response. Returns (0, 0) if usage is
+    unavailable (some providers omit it) -- callers should treat that as
+    "unknown", not "free"."""
+    usage = getattr(response, "usage", None)
+    if usage is None:
+        return 0, 0
+    input_tokens = int(
+        getattr(usage, "prompt_tokens", None) or getattr(usage, "input_tokens", None) or 0
+    )
+    output_tokens = int(
+        getattr(usage, "completion_tokens", None) or getattr(usage, "output_tokens", None) or 0
+    )
+    return input_tokens, output_tokens
+
+
+def check_and_accumulate_cost(agent: Any, response: Any) -> None:
+    """Add this call's estimated cost to the agent's running session total,
+    then raise SessionCostExceeded if the *new* total is past the configured
+    ceiling. Checked after accumulating (not before) so the ceiling reflects
+    real spend up to and including the call that just completed -- the next
+    call is what actually gets stopped, matching how solve_max_steps already
+    behaves (checked once per round, not a mid-call kill)."""
+    safety = getattr(getattr(agent, "config", None), "safety", None)
+    limit_usd = float(getattr(safety, "max_session_cost_usd", 0.0) or 0.0)
+    if limit_usd <= 0:
+        return  # 0 = disabled, matches this codebase's existing "0 = unlimited" convention
+
+    model = str(getattr(getattr(agent, "config", None), "llm", None) and agent.config.llm.model or "")
+    input_tokens, output_tokens = extract_usage_tokens(response)
+    cost = estimate_cost_usd(model, input_tokens, output_tokens)
+
+    spent_so_far = float(getattr(agent, "session_cost_usd", 0.0) or 0.0) + cost
+    try:
+        agent.session_cost_usd = spent_so_far
+    except AttributeError:
+        pass
+
+    if spent_so_far > limit_usd:
+        raise SessionCostExceeded(spent_so_far, limit_usd)

--- a/vulnclaw/agent/llm_client.py
+++ b/vulnclaw/agent/llm_client.py
@@ -37,6 +37,10 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 from vulnclaw.agent.context_budget import prepare_context  # noqa: E402
+from vulnclaw.agent.cost_budget import (  # noqa: E402
+    SessionCostExceeded,
+    check_and_accumulate_cost,
+)
 from vulnclaw.agent.token_counter import (  # noqa: E402
     estimate_tokens,
     group_tool_exchanges,
@@ -510,6 +514,19 @@ async def _call_with_persistent_retries_unbudgeted(
 async def _call_with_persistent_retries(
     agent: AgentContext, request_fn, stage_label: str, max_retries: int = 20
 ) -> tuple[Any, int]:
+    """Note: the subagent-scoped token budget above (reserve/settle) and the
+    session-wide USD cost ceiling below are two independent, complementary
+    checks -- the former bounds a sub-agent's own token allotment, the latter
+    bounds real dollar spend for the whole session (main agent included,
+    which the subagent budget never covers -- see is_subagent() in
+    subagent/budget.py). Checked once per call, before issuing it, mirroring
+    how solve_max_steps already gates once per round rather than mid-call.
+    """
+    safety = getattr(getattr(agent, "config", None), "safety", None)
+    limit_usd = float(getattr(safety, "max_session_cost_usd", 0.0) or 0.0)
+    if limit_usd > 0 and float(getattr(agent, "session_cost_usd", 0.0) or 0.0) > limit_usd:
+        raise SessionCostExceeded(float(agent.session_cost_usd), limit_usd)
+
     admission = _reserve_subagent_llm_request(agent)
     try:
         response, retries = await _call_with_persistent_retries_unbudgeted(
@@ -518,6 +535,14 @@ async def _call_with_persistent_retries(
         actual_tokens = _record_subagent_llm_usage(agent, response)
         _settle_subagent_llm_admission(agent, admission, actual_tokens)
         admission = None
+        try:
+            check_and_accumulate_cost(agent, response)
+        except SessionCostExceeded:
+            # This call's tokens are already spent -- returning the response
+            # it paid for doesn't cost anything further. The pre-check above
+            # stops the *next* call once session_cost_usd (just updated) is
+            # past the ceiling.
+            pass
         return response, retries
     finally:
         if admission is not None:

--- a/vulnclaw/config/schema.py
+++ b/vulnclaw/config/schema.py
@@ -302,6 +302,21 @@ class SafetyConfig(BaseModel):
         description="Max number of tool calls executed concurrently per round (1=serial)",
     )
 
+    # ── Real dollar cost ceiling, independent of step count ─────────────
+    # session.solve_max_steps bounds *how many rounds* a solve loop may run,
+    # not what those rounds cost -- 240 rounds of cheap short completions and
+    # 240 rounds of reasoning_effort=high on an expensive model are very
+    # different dollar amounts, and nothing stopped the latter before this.
+    max_session_cost_usd: float = Field(
+        default=0.0,
+        description=(
+            "Hard USD ceiling on estimated LLM spend for one session, independent of "
+            "solve_max_steps. 0 = disabled (no cost ceiling). Cost is approximated from "
+            "actual token usage x a built-in per-model price table (see agent/cost_budget.py) "
+            "-- close enough to catch a runaway loop, not a billing reconciliation tool."
+        ),
+    )
+
 
 class SessionConfig(BaseModel):
     """Session / output configuration."""


### PR DESCRIPTION
`session.solve_max_steps` (default 240) bounds how many autonomous tool-calling rounds a solve loop may run, but says nothing about what those rounds actually cost. 240 rounds of cheap short completions and 240 rounds of `reasoning_effort=high` on an expensive model are very different dollar amounts, and nothing stopped the latter before this.

The existing subagent-scoped token budget (`agent/subagent/budget.py`, `UsageBudget`) doesn't cover this gap either — it's gated by `is_subagent()`, so the main agent (the one actually running `vulnclaw chat`/`recon`/`solve`) is never bounded by it.

## What this adds

`agent/cost_budget.py`: a small per-model USD/1M-token price table (best-effort, matched by substring against the configured model name, conservative fallback for unlisted models), `SessionCostExceeded`, and `check_and_accumulate_cost()`. New `safety.max_session_cost_usd` config field, default `0.0` (disabled — matches this codebase's existing "0 = unlimited" convention elsewhere).

Wired into `_call_with_persistent_retries` — the one function every LLM call (main agent and subagents alike) funnels through:
- Checked once per call, **before** issuing it (mirrors how `solve_max_steps` already gates once per round, not mid-call).
- Accumulated from actual `response.usage` right after a successful call.
- Deliberately lets the call that crosses the ceiling still return its own response — those tokens are already spent, discarding the answer they paid for buys nothing. The pre-check at the top of the same function is what stops the *next* call once the total is past the limit.

## Verification

```
estimate_cost_usd(gpt-4o, 1_000_000 in, 100_000 out): 3.5   # matches 2.50 + 1.00 hand-calc

call 1 ok, session_cost_usd = 0.0045
call 2 ok (over budget now, but its own response wasn't discarded), session_cost_usd = 0.0145
call 3 correctly BLOCKED before running: Session cost budget exceeded: $0.0145 spent > $0.01 limit

unlimited (0) ceiling with $999 already 'spent': still allowed -> ok
```