### PR TITLE
security: self-XSS in HTML reports + plaintext credentials in session files

### DIFF
--- a/vulnclaw/agent/context.py
+++ b/vulnclaw/agent/context.py
@@ -15,6 +15,7 @@ from pydantic import AliasChoices, BaseModel, Field, PrivateAttr
 
 from vulnclaw.agent.agent_state import AgentState
 from vulnclaw.agent.reasoning_state import ReasoningState
+from vulnclaw.config.secret_redaction import redact_secrets
 
 # ──────────────────────────────────────────────────────────────
 # 叶子类型已提取到 config/domain_models.py，此处重新导出以保持兼容。
@@ -1019,6 +1020,15 @@ class SessionState(BaseModel):
             data = self._checkpoint_transform(self, data)
         data["executed_steps"] = self.executed_steps
         content = json.dumps(data, ensure_ascii=False, indent=2)
+        # 修改者: security-hardening pass (plaintext credential persistence fix)
+        # 修改原因: this session dump includes raw tool call arguments/results
+        # verbatim -- a captured Authorization header, Set-Cookie, or a
+        # brute_force_login success carries a real, reusable credential for
+        # the target straight onto disk with zero redaction. Applied once
+        # here (not per-field) so it covers wherever a secret ended up in
+        # this deeply nested, varied structure -- see
+        # config/secret_redaction.py for the exact patterns and their limits.
+        content = redact_secrets(content)
 
         content_hash = hashlib.md5(content.encode("utf-8")).hexdigest()
         if content_hash == self._content_hash:

--- a/vulnclaw/config/secret_redaction.py
+++ b/vulnclaw/config/secret_redaction.py
@@ -1,0 +1,79 @@
+"""Redact obvious secrets from persisted session/target-state text.
+
+Why this exists: SessionState.save() (agent/context.py) and target_state/
+persist the full session -- including raw tool call arguments and results --
+to plaintext JSON on disk with zero redaction. A session that exercises an
+authenticated target (a successful brute_force_login, a fetch/stealth_fetch
+call carrying a real Authorization header, a captured Set-Cookie) writes that
+literal credential to `~/.vulnclaw/sessions/*.json`. Sharing that file for
+debugging, or accidentally committing it, leaks a real credential for
+whatever target was being tested.
+
+Deliberately a structural, string-level pass applied once to the final
+serialized JSON text, not a per-field allowlist: the session model is deeply
+nested and varied (tool args, tool results, findings, evidence), and a field
+-by-field approach would need updating every time a new tool or finding
+shape is added. A regex pass over the fully-serialized text catches a secret
+wherever it ended up, at the cost of being pattern-based rather than
+semantic -- it will not catch a credential in a shape none of these patterns
+anticipate, so this is a floor, not a guarantee.
+"""
+
+from __future__ import annotations
+
+import re
+
+_REDACTED = "[REDACTED]"
+
+# Each pattern captures the sensitive value in group 2, with groups 1/3
+# preserving the surrounding quotes/key/prefix so the output stays valid
+# JSON / readable text. `\\?"` (an optional single backslash before each
+# quote) matches both a bare JSON key/value ("Authorization": "...") AND the
+# same thing one level deep inside a JSON string -- e.g. a tool result string
+# that itself contains a rendered header dict as text
+# (`"result": "...{\"Set-Cookie\": \"...\"}..."`), which is exactly the shape
+# _format_fetch_response's `f"Headers: {dict(response.headers)}"` produces
+# once that whole string becomes a session-JSON value. Only handles one level
+# of escaping; a secret nested two JSON layers deep would need its own
+# backslash-count, which this deliberately does not chase further -- see the
+# module docstring on this being a floor, not a guarantee.
+_JSON_KEY_PATTERNS: tuple[re.Pattern, ...] = tuple(
+    re.compile(pattern, re.IGNORECASE)
+    for pattern in (
+        r'(\\?"(?:authorization|set-cookie|cookie)\\?"\s*:\s*\\?")([^"]*?)(\\?")',
+        r'(\\?"(?:password|passwd|pwd|api_key|apikey|secret|access_token|'
+        r'refresh_token|client_secret|bearer_token|session_token)\\?"\s*:\s*\\?")([^"]*?)(\\?")',
+    )
+)
+
+_HEADER_TEXT_PATTERNS: tuple[re.Pattern, ...] = tuple(
+    re.compile(pattern, re.IGNORECASE)
+    for pattern in (
+        r"(Authorization:\s*(?:Bearer|Basic|Digest)\s+)(\S+)",
+        r"(Set-Cookie:\s*[^=;\s]+=)([^;\s\"']+)",
+        r"(Cookie:\s*[^=;\s]+=)([^;\s\"']+)",
+    )
+)
+
+# Provider-specific credential shapes worth catching even outside a
+# recognizable key/header context (e.g. embedded in free-text evidence).
+_BARE_SECRET_PATTERNS: tuple[re.Pattern, ...] = (
+    re.compile(r"AKIA[0-9A-Z]{16}"),  # AWS access key id
+    re.compile(r"gh[pousr]_[A-Za-z0-9]{36,}"),  # GitHub tokens (ghp_/gho_/ghu_/ghs_/ghr_)
+)
+
+
+def redact_secrets(text: str) -> str:
+    """Best-effort redaction of credentials/tokens from serialized session
+    text. Preserves JSON/text structure around the redacted value."""
+    if not text:
+        return text
+
+    for pattern in _JSON_KEY_PATTERNS:
+        text = pattern.sub(lambda m: f"{m.group(1)}{_REDACTED}{m.group(3)}", text)
+    for pattern in _HEADER_TEXT_PATTERNS:
+        text = pattern.sub(lambda m: f"{m.group(1)}{_REDACTED}", text)
+    for pattern in _BARE_SECRET_PATTERNS:
+        text = pattern.sub(_REDACTED, text)
+
+    return text

--- a/vulnclaw/report/generator.py
+++ b/vulnclaw/report/generator.py
@@ -512,8 +512,22 @@ def generate_report(
         report_content += "\n\n" + _render_target_state_context(target_state_context)
 
     if report_format.lower() == "html":
+        # 修改者: security-hardening pass (self-XSS in HTML report fix)
+        # 修改原因: this template used to render with Jinja2's default
+        # autoescape=False. report_content is built from finding evidence/PoC
+        # text verbatim -- for an XSS finding, that text *is* something like
+        # "<script>alert(1)</script>" by construction, since documenting the
+        # payload is the whole point of the finding. Rendered unescaped, that
+        # payload executes the moment the operator (or anyone they share the
+        # report with) opens their own report in a browser -- <pre> only
+        # affects whitespace display, it does not stop the browser from
+        # parsing tags inside it. autoescape=True makes Jinja2 HTML-escape
+        # `content` (and any other future variables in this template)
+        # automatically; the escaped text is still fully readable, it just
+        # can no longer execute as markup.
         html_content = Template(
-            """<!doctype html><html><head><meta charset="utf-8"><title>VulnClaw Report</title></head><body><pre>{{ content }}</pre></body></html>"""
+            """<!doctype html><html><head><meta charset="utf-8"><title>VulnClaw Report</title></head><body><pre>{{ content }}</pre></body></html>""",
+            autoescape=True,
         ).render(content=report_content)
         output = output.with_suffix(".html") if output.suffix.lower() != ".html" else output
         output.write_text(html_content, encoding="utf-8")

--- a/vulnclaw/target_state/store.py
+++ b/vulnclaw/target_state/store.py
@@ -14,8 +14,9 @@ from typing import Any, Optional
 # 修改原因: 消除 V3 违规 — 叶子类型已移至 config/domain_models.py。
 from vulnclaw.agent.context import SessionState
 from vulnclaw.config.domain_models import PentestPhase
+from vulnclaw.config.secret_redaction import redact_secrets
 from vulnclaw.config.settings import TARGETS_DIR, ensure_dirs
-from vulnclaw.run_context import RunContext, atomic_write_json
+from vulnclaw.run_context import RunContext, atomic_write_json, atomic_write_text
 from vulnclaw.target_state.planner import (
     build_resume_plan,
     compute_finding_confidence,
@@ -275,8 +276,17 @@ def save_target_state(
     else:
         snapshots = _snapshot_dir(model.raw)
     snapshots.mkdir(parents=True, exist_ok=True)
-    atomic_write_json(path, raw)
-    atomic_write_json(snapshots / f"{snapshot_id}.json", raw)
+    # 修改者: security-hardening pass (plaintext credential persistence fix)
+    # 修改原因: `raw` carries the full session (tool call args/results
+    # verbatim) into a *second* on-disk location beyond SessionState.save()'s
+    # own file -- same redaction, applied once here via atomic_write_text
+    # instead of atomic_write_json so the generic JSON-writing helper (used
+    # elsewhere for things like config files that may legitimately need
+    # their own keys preserved) doesn't get redaction behavior forced onto
+    # every caller.
+    redacted_content = redact_secrets(json.dumps(raw, ensure_ascii=False, indent=2))
+    atomic_write_text(path, redacted_content)
+    atomic_write_text(snapshots / f"{snapshot_id}.json", redacted_content)
 
     if run_context is not None:
         atomic_write_json(run_context.target_json_path(model), model.to_manifest())


### PR DESCRIPTION
Two independent findings from auditing the report/persistence paths for what actually happens to sensitive data.

## 1. Self-XSS in HTML report generation (`report/generator.py`)

The HTML report template rendered with Jinja2's default `autoescape=False`. `report_content` is built from finding evidence/PoC text verbatim — for an XSS finding, that text **is** something like `<script>alert(1)</script>` by construction, since documenting the payload is the whole point of the finding. Rendered unescaped, that payload executes the moment the operator (or anyone they share the report with) opens their own report in a browser — `<pre>` only affects whitespace display, it does not stop the browser from parsing tags inside it.

Fixed with `autoescape=True` on this template; escaped text is still fully readable, it just can no longer execute as markup.

## 2. Plaintext credentials in persisted session/target-state files

`agent/context.py`'s `SessionState.save()` and `target_state/store.py`'s `save_target_state()` both persist the full session — including raw tool call arguments/results — to plaintext JSON with zero redaction. A captured `Authorization` header, `Set-Cookie`, or a successful `brute_force_login` writes that literal, reusable credential for the target straight onto disk. Sharing that file for debugging, or accidentally committing it, leaks a real credential.

Added `config/secret_redaction.py`: a regex pass over the final serialized JSON text (not a per-field allowlist — the session model is deeply nested and varied, and a field-by-field approach would need updating every time a new tool/finding shape is added). Handles both a bare JSON key/value and the same shape one level deep inside a JSON string (e.g. a tool result that itself contains a rendered header dict as text — exactly what `_format_fetch_response`'s `f"Headers: {dict(response.headers)}"` produces once that whole string becomes a session-JSON value). Deliberately a floor, not a guarantee — see the module docstring for the exact patterns and limits.

Wired into both persistence paths right before the write. Left `run_context.py`'s generic `atomic_write_json` helper untouched — it's used elsewhere for things like config files that may legitimately need their own keys preserved, so redaction shouldn't be forced onto every caller of a shared low-level utility; `store.py`'s two session-carrying call sites use `atomic_write_text` with pre-redacted content instead.

## Verification

- XSS payload renders as escaped, inert text (`&lt;script&gt;...`).
- A realistic sample (`Authorization`/`Cookie`/`Set-Cookie` headers, a `brute_force_login` password, an AWS key, a GitHub token, including the escaped-nested-JSON-string form) is fully redacted.
- Benign findings text passes through byte-for-byte unchanged (no false positives), and the JSON stays valid after redaction.