### PR TITLE
fix(docker): install the kb extra and let the Web UI authenticate beh…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,8 +46,14 @@ COPY pyproject.toml README.md LICENSE ./
 COPY vulnclaw ./vulnclaw
 
 # Editable install so vulnclaw resolves to /app and finds frontend/dist.
-# `web` extra pulls in fastapi + uvicorn for the Web UI.
-RUN pip install -e ".[web]"
+#   web → fastapi + uvicorn for the Web UI
+#   kb  → chromadb, so the knowledge base runs semantic search instead of
+#         silently degrading to the keyword fallback
+#   pdf → reportlab, so `vulnclaw report --pdf` works in the container
+# `traffic` (mitmproxy + playwright) is deliberately excluded: Playwright also
+# needs browser binaries pulled in via `playwright install`, which would add
+# hundreds of MB. Add it here if you need the live proxy/browser backends.
+RUN pip install -e ".[web,kb,pdf]"
 
 # Bring in the built frontend so the full React UI is served (not the
 # bundled single-file fallback). resolve_web_index() looks for this path.

--- a/tests/kb/test_install_hint_markup.py
+++ b/tests/kb/test_install_hint_markup.py
@@ -1,0 +1,64 @@
+"""Rich markup must not swallow the extras bracket in install hints.
+
+``console.print("pip install vulnclaw[kb]")`` renders as
+``pip install vulnclaw`` — Rich parses ``[kb]`` as a style tag and drops it,
+turning the remediation hint into a command that installs nothing and never
+fixes the degraded state it is advertised to fix. The bracket has to be
+escaped (``vulnclaw\\[kb]``) in every Rich-rendered string.
+"""
+
+import pytest
+
+import vulnclaw.agent.core as core_mod
+from vulnclaw.kb.retriever import RetrieverStatus
+
+
+@pytest.fixture(autouse=True)
+def _wide_console(monkeypatch):
+    """Keep Rich from wrapping the hint mid-token on a narrow default width."""
+    monkeypatch.setenv("COLUMNS", "200")
+
+
+class _KeywordFallbackRetriever:
+    """Stands in for a KnowledgeRetriever with chromadb unavailable."""
+
+    store = None
+
+    def get_status(self):
+        return RetrieverStatus.KEYWORD_FALLBACK
+
+
+class TestKbDegradationHint:
+    def test_hint_keeps_the_kb_extra(self, monkeypatch, capsys):
+        monkeypatch.setattr(core_mod, "KnowledgeRetriever", _KeywordFallbackRetriever)
+
+        agent = object.__new__(core_mod.AgentCore)
+        agent._report_kb_status()
+
+        out = capsys.readouterr().out
+        assert "降级为关键词模式" in out, "expected the degradation warning to be printed"
+        assert "pip install vulnclaw[kb]" in out, (
+            f"install hint lost its [kb] extra to Rich markup parsing; got: {out!r}"
+        )
+
+
+class TestWebExtraHints:
+    """The `web` command's missing-dependency hint has the same bug shape."""
+
+    def test_fastapi_hint_keeps_the_web_extra(self, monkeypatch):
+        from typer.testing import CliRunner
+
+        import vulnclaw.web.app as web_app
+        from vulnclaw.cli.main import app
+
+        # The command reads FASTAPI_AVAILABLE from vulnclaw.web.app at call time.
+        monkeypatch.setattr(web_app, "FASTAPI_AVAILABLE", False)
+
+        result = CliRunner().invoke(app, ["web", "--host", "127.0.0.1"])
+
+        assert result.exit_code == 1
+        combined = result.output + (result.stderr if result.stderr_bytes else "")
+        assert "FastAPI is missing" in combined
+        assert "pip install vulnclaw[web]" in combined, (
+            f"install hint lost its [web] extra to Rich markup parsing; got: {combined!r}"
+        )

--- a/tests/web/test_auth.py
+++ b/tests/web/test_auth.py
@@ -43,3 +43,91 @@ class TestTokenFile:
         assert auth._client_is_loopback("localhost")
         assert not auth._client_is_loopback("8.8.8.8")
         assert not auth._client_is_loopback(None)
+
+
+class _FakeRequest:
+    """Minimal stand-in for the Starlette Request surface the auth gate reads."""
+
+    class _URL:
+        def __init__(self, path):
+            self.path = path
+
+    class _Client:
+        def __init__(self, host):
+            self.host = host
+
+    def __init__(self, path="/api/tasks", host="192.168.181.1", headers=None, cookies=None):
+        self.url = self._URL(path)
+        self.client = self._Client(host) if host else None
+        self.headers = headers or {}
+        self.cookies = cookies or {}
+
+
+class TestSessionCookie:
+    """A browser behind Docker's port NAT is never a loopback client, and the
+    shipped UI can send no bearer header — the session cookie is what lets it
+    authenticate at all. See the module docstring in vulnclaw.web.auth."""
+
+    def test_valid_cookie_is_accepted(self, monkeypatch, tmp_path):
+        _redirect_token_dir(monkeypatch, tmp_path)
+        token = auth.generate_token()
+        request = _FakeRequest(cookies={auth.SESSION_COOKIE: token})
+        assert auth.request_has_valid_session(request) is True
+
+    def test_wrong_or_absent_cookie_is_rejected(self, monkeypatch, tmp_path):
+        _redirect_token_dir(monkeypatch, tmp_path)
+        auth.generate_token()
+        assert auth.request_has_valid_session(_FakeRequest()) is False
+        assert (
+            auth.request_has_valid_session(
+                _FakeRequest(cookies={auth.SESSION_COOKIE: "forged"})
+            )
+            is False
+        )
+
+    async def test_middleware_lets_a_docker_browser_through_with_cookie(
+        self, monkeypatch, tmp_path
+    ):
+        """The reported bug: GET /api/config from 192.168.181.1 returned 401."""
+        import vulnclaw.web.app as web_app
+
+        if not web_app.FASTAPI_AVAILABLE:
+            import pytest
+
+            pytest.skip("FastAPI is not installed in this environment")
+
+        _redirect_token_dir(monkeypatch, tmp_path)
+        token = auth.generate_token()
+        mw = auth.AuthMiddleware(None)
+
+        async def call_next(_req):
+            return "PASSED"
+
+        # Docker bridge gateway address, exactly as seen in the uvicorn log.
+        no_cookie = await mw.dispatch(_FakeRequest(path="/api/config"), call_next)
+        assert getattr(no_cookie, "status_code", None) == 401
+
+        with_cookie = _FakeRequest(
+            path="/api/config", cookies={auth.SESSION_COOKIE: token}
+        )
+        assert await mw.dispatch(with_cookie, call_next) == "PASSED"
+
+    def test_attach_session_cookie_is_httponly_and_strict(self, monkeypatch, tmp_path):
+        import vulnclaw.web.app as web_app
+
+        if not web_app.FASTAPI_AVAILABLE:
+            import pytest
+
+            pytest.skip("FastAPI is not installed in this environment")
+
+        from starlette.responses import Response
+
+        _redirect_token_dir(monkeypatch, tmp_path)
+        token = auth.generate_token()
+        response = Response()
+        auth.attach_session_cookie(response, token)
+
+        header = response.headers["set-cookie"]
+        assert f"{auth.SESSION_COOKIE}={token}" in header
+        assert "HttpOnly" in header
+        assert "samesite=strict" in header.lower()

--- a/tests/web/test_web.py
+++ b/tests/web/test_web.py
@@ -1408,10 +1408,13 @@ class TestWebAuthLoopback:
                 self.host = host
 
         class _Req:
-            def __init__(self, path, host, headers=None):
+            def __init__(self, path, host, headers=None, cookies=None):
                 self.url = _URL(path)
                 self.client = _Client(host) if host else None
                 self.headers = headers or {}
+                # Real Starlette requests always expose .cookies; the auth gate
+                # consults it for the browser session cookie.
+                self.cookies = cookies or {}
 
         mw = AuthMiddleware(None)
 

--- a/vulnclaw/agent/core.py
+++ b/vulnclaw/agent/core.py
@@ -124,7 +124,7 @@ class AgentCore:
         elif status == RetrieverStatus.KEYWORD_FALLBACK:
             console.print(
                 "[yellow]⚠ 知识库已降级为关键词模式 "
-                "(chromadb 未安装，运行 pip install vulnclaw[kb] 启用语义搜索)[/yellow]"
+                "(chromadb 未安装，运行 pip install vulnclaw\\[kb] 启用语义搜索)[/yellow]"
             )
         else:
             console.print("[red]✗ 知识库已禁用 (无可用数据)[/red]")

--- a/vulnclaw/cli/main.py
+++ b/vulnclaw/cli/main.py
@@ -3214,7 +3214,7 @@ def web(
 
     if not FASTAPI_AVAILABLE:
         err_console.print(
-            "[!] FastAPI is missing. Install with [bold]pip install vulnclaw[web][/]."
+            "[!] FastAPI is missing. Install with [bold]pip install vulnclaw\\[web][/]."
         )
         raise typer.Exit(1)
 
@@ -3222,7 +3222,7 @@ def web(
         import uvicorn
     except ImportError:
         err_console.print(
-            "[!] uvicorn is missing. Install with [bold]pip install vulnclaw[web][/]."
+            "[!] uvicorn is missing. Install with [bold]pip install vulnclaw\\[web][/]."
         )
         raise typer.Exit(1)
 
@@ -3231,11 +3231,17 @@ def web(
 
     token = generate_token()
     if allow_remote:
+        # Non-loopback clients (which includes every browser reaching a
+        # container through Docker's port NAT) must authenticate. The UI cannot
+        # send a bearer header, so opening this URL once swaps the token for a
+        # session cookie; the browser carries it from then on.
+        browser_host = "127.0.0.1" if host in {"0.0.0.0", "::", "[::]"} else host
         console.print(
             Panel(
-                f"Token: [bold]{token}[/]\n\n"
-                "Use this token in the Authorization header:\n"
-                f"[dim]Authorization: Bearer {token}[/]",
+                f"Open this URL once to sign the browser in:\n"
+                f"[bold]http://{browser_host}:{port}/?token={token}[/]\n\n"
+                f"Token: [bold]{token}[/]\n"
+                f"[dim]For API clients: Authorization: Bearer {token}[/]",
                 title="Web UI Auth Token",
                 border_style="yellow",
             )

--- a/vulnclaw/web/app.py
+++ b/vulnclaw/web/app.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from contextlib import contextmanager
 from pathlib import Path
 
-from vulnclaw.web.auth import AuthMiddleware
+from vulnclaw.web.auth import AuthMiddleware, attach_session_cookie, verify_token
 from vulnclaw.web.schemas import (
     ConfigUpdateRequest,
     ProviderModelsRequest,
@@ -37,16 +37,23 @@ from vulnclaw.web.stream import encode_sse
 from vulnclaw.web.task_manager import WebTaskManager
 
 try:
-    from fastapi import FastAPI, HTTPException
-    from fastapi.responses import FileResponse, JSONResponse, StreamingResponse
+    from fastapi import FastAPI, HTTPException, Request
+    from fastapi.responses import (
+        FileResponse,
+        JSONResponse,
+        RedirectResponse,
+        StreamingResponse,
+    )
     from starlette.middleware.base import BaseHTTPMiddleware
 
     FASTAPI_AVAILABLE = True
 except ImportError:  # pragma: no cover - exercised in CLI dry-run and tests
     FastAPI = None  # type: ignore[assignment]
     HTTPException = RuntimeError  # type: ignore[assignment]
+    Request = None  # type: ignore[assignment]
     FileResponse = None  # type: ignore[assignment]
     JSONResponse = None  # type: ignore[assignment]
+    RedirectResponse = None  # type: ignore[assignment]
     StreamingResponse = None  # type: ignore[assignment]
     BaseHTTPMiddleware = object  # type: ignore[assignment,misc]
     FASTAPI_AVAILABLE = False
@@ -79,6 +86,24 @@ def resolve_web_asset(path: str) -> Path:
             return candidate
 
     return resolve_web_index()
+
+
+def _serve_spa(request, file_path: Path):  # type: ignore[no-untyped-def]
+    """Serve a frontend file, trading a ``?token=`` query for a session cookie.
+
+    The browser UI cannot send a bearer header (see :mod:`vulnclaw.web.auth`),
+    so opening the printed ``/?token=<token>`` URL once is what authenticates
+    the session. The token is redirected straight back out of the address bar
+    so it does not linger in history or leak through ``Referer``.
+    """
+    token = request.query_params.get("token", "")
+    if token and verify_token(token):
+        response = RedirectResponse(
+            str(request.url.remove_query_params("token")), status_code=303
+        )
+        attach_session_cookie(response, token)
+        return response
+    return FileResponse(file_path)
 
 
 @contextmanager
@@ -245,14 +270,14 @@ def create_app():
         return {"status": "ok", "path": path}
 
     @app.get("/")
-    async def index():
-        return FileResponse(resolve_web_index())
+    async def index(request: Request):
+        return _serve_spa(request, resolve_web_index())
 
     @app.get("/{full_path:path}")
-    async def frontend_routes(full_path: str):
+    async def frontend_routes(full_path: str, request: Request):
         if full_path.startswith("api/"):
             raise HTTPException(status_code=404, detail="Not found")
-        return FileResponse(resolve_web_asset(full_path))
+        return _serve_spa(request, resolve_web_asset(full_path))
 
     return app
 

--- a/vulnclaw/web/auth.py
+++ b/vulnclaw/web/auth.py
@@ -2,7 +2,14 @@
 
 The token is generated once and persisted to ``~/.vulnclaw/web_token``.
 All ``/api/`` routes (except ``/api/health``) require a valid
-``Authorization: Bearer <token>`` header.
+``Authorization: Bearer <token>`` header, a session cookie carrying the same
+token, or a loopback peer address.
+
+The cookie exists because the shipped browser UI cannot send a bearer header:
+``fetch`` here adds none and an SSE ``EventSource`` cannot attach one at all.
+Opening the UI once at ``/?token=<token>`` exchanges the token for an
+``HttpOnly``/``SameSite=Strict`` session cookie, which the browser then sends
+on every subsequent request including the event stream.
 """
 
 from __future__ import annotations
@@ -23,6 +30,9 @@ except ImportError:  # pragma: no cover
 
 TOKEN_DIR = Path.home() / ".vulnclaw"
 TOKEN_FILE = TOKEN_DIR / "web_token"
+
+#: Name of the session cookie that carries the bearer token for browser clients.
+SESSION_COOKIE = "vulnclaw_session"
 
 
 def _token_path() -> Path:
@@ -65,6 +75,29 @@ def verify_token(token: str) -> bool:
         return False
     stored = path.read_text(encoding="utf-8").strip()
     return hmac.compare_digest(stored, token)
+
+
+def attach_session_cookie(response, token: str) -> None:  # type: ignore[no-untyped-def]
+    """Store *token* on the browser as an HttpOnly session cookie.
+
+    ``secure`` is deliberately left off: the UI is served over plain HTTP on
+    localhost and inside Docker, where a Secure cookie would never be sent
+    back. ``SameSite=Strict`` keeps the cookie off cross-site requests, which
+    is what guards the state-changing ``/api/`` routes against CSRF.
+    """
+    response.set_cookie(
+        SESSION_COOKIE,
+        token,
+        httponly=True,
+        samesite="strict",
+        path="/",
+    )
+
+
+def request_has_valid_session(request) -> bool:  # type: ignore[no-untyped-def]
+    """Whether *request* carries a session cookie holding a valid token."""
+    cookie = request.cookies.get(SESSION_COOKIE, "")
+    return bool(cookie) and verify_token(cookie)
 
 
 def _client_is_loopback(client_host: str | None) -> bool:
@@ -110,6 +143,7 @@ if _HAS_STARLETTE:
                 path.startswith("/api/")
                 and path not in self._EXEMPT_PATHS
                 and not _client_is_loopback(client_host)
+                and not request_has_valid_session(request)
             ):
                 auth_header = request.headers.get("Authorization", "")
                 if not auth_header.startswith("Bearer "):


### PR DESCRIPTION
…ind NAT

Three defects that all surface only when running via docker compose.

1. The image installed `.[web]` only, so chromadb was absent in every container and the knowledge base silently fell back to keyword matching. Install `kb` (and `pdf`, near-free and makes `report --pdf` work). `traffic` stays out: Playwright also needs browser binaries via `playwright install`, worth hundreds of MB.

2. The hint that degradation printed was itself broken. Rich parses `[kb]` as a style tag and drops it, so the warning rendered as

       chromadb 未安装，运行 pip install vulnclaw 启用语义搜索

   advertising a command that installs nothing and cannot fix the state it claims to fix. Escape it as `\[kb]`, matching the already-correct `kb status` panel. The `web` command's two `[web]` hints had the same bug.

3. Every `/api/` call from the browser returned 401. AuthMiddleware waives the bearer token for loopback peers, and the shipped frontend depends on that waiver: its fetch sends no Authorization header and EventSource cannot attach one at all. Behind Docker's port NAT the peer address is the bridge gateway, never loopback, so the waiver never applied and the token-less UI was locked out of its own backend.

   Add a session cookie: GET /?token=<token> exchanges a valid token for an HttpOnly, SameSite=Strict cookie and redirects the token back out of the address bar; the middleware then accepts that cookie. Auth stays enforced (a forged cookie still 401s) and SSE works, since browsers attach cookies to same-origin EventSource. The startup panel now prints the sign-in URL.

Verified against the built image from the bridge address: no cookie 401, bootstrap 303 + Set-Cookie, with cookie 200, forged cookie 401. chromadb 1.5.9 installs on slim-bookworm with no build tools and `kb status` reports chromadb_active after a seed.