### PR TITLE
docs: list solve and plugins in the --help command snippet (#157)

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,8 @@ $ vulnclaw --help
  Usage: vulnclaw [OPTIONS] COMMAND [ARGS]...
 
  Commands:
-   run           🚀 一键全流程渗透测试
+   run           🚀 一键全流程渗透测试（默认使用 solve 引擎）
+   solve         🧩 目标驱动求解（模型主导，无固定轮数）
    persistent    🔄 持续性渗透测试（100轮/周期）
    recon         🔍 仅信息收集阶段
    scan          🔎 执行漏洞扫描阶段
@@ -195,6 +196,7 @@ $ vulnclaw --help
    report        📝 从会话记录生成报告
    repl          💬 启动经典 REPL 交互界面
    config        ⚙️  管理配置（set/get/list/provider）
+   plugins       🧩 管理漏洞检测插件（list/info/run）
    init          🔧 初始化配置
    doctor        🏥  检查运行环境
    tui           🖥️  打开终端图形化工作台

--- a/README_EN.md
+++ b/README_EN.md
@@ -192,7 +192,8 @@ $ vulnclaw --help
  Usage: vulnclaw [OPTIONS] COMMAND [ARGS]...
 
  Commands:
-   run           🚀 Full pentest in one shot
+   run           🚀 Full pentest in one shot (defaults to the solve engine)
+   solve         🧩 Goal-driven solver (model-led, no fixed rounds)
    persistent    🔄 Persistent pentesting (100 rounds/cycle)
    recon         🔍 Reconnaissance only
    scan          🔎 Vulnerability scanning
@@ -200,6 +201,7 @@ $ vulnclaw --help
    report        📝 Generate report from session JSON
    repl          💬 Start the classic REPL
    config        ⚙️  Manage config (set/get/list/provider)
+   plugins       🧩 Manage vulnerability detection plugins (list/info/run)
    init          🔧 Initialize configuration
    doctor        🏥  Check runtime environment
    tui           🖥️  Open the terminal UI workbench


### PR DESCRIPTION
## What

Adds the `solve` and `plugins` commands to the `$ vulnclaw --help` snippet in the CLI Command Reference of both `README_EN.md` and `README.md`.

## Why

Part of the documentation-consistency discussion in #157. As @Cid-oe noted there, the `solve` command is documented in the command table but is missing from the `--help` example shown just above it. The same applied to `plugins`.

Both commands are real and registered in `vulnclaw/cli/main.py` (`solve` is an `@app.command()`; `plugins` is a Typer sub-app), and both already appear in the command-reference table directly below the snippet — so the `--help` block was incomplete and, because `solve` is the default engine, misleading about the flagship command.

## Change

```
   run           🚀 Full pentest in one shot (defaults to the solve engine)
   solve         🧩 Goal-driven solver (model-led, no fixed rounds)
   ...
   config        ⚙️  Manage config (set/get/list/provider)
   plugins       🧩 Manage vulnerability detection plugins (list/info/run)
```

Docs-only; no code changes. The Chinese `README.md` gets the same fix for parity.

Refs #157