### PR TITLE
fix(mcp): pass read_timeout_seconds as float, not timedelta (#171)

### DIFF
--- a/vulnclaw/mcp/_probe_mixin.py
+++ b/vulnclaw/mcp/_probe_mixin.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 import asyncio
 import concurrent.futures
-from datetime import timedelta
 from typing import Any
 from urllib.parse import urlparse
 
@@ -196,7 +195,7 @@ class ProbeMixin:
                 url, headers=headers, timeout=connect_s, sse_read_timeout=read_s
             ) as (read_stream, write_stream, _get_session_id):
                 async with ClientSession(
-                    read_stream, write_stream, read_timeout_seconds=timedelta(seconds=read_s)
+                    read_stream, write_stream, read_timeout_seconds=read_s
                 ) as session:
                     await session.initialize()
                     tools = await session.list_tools()
@@ -226,7 +225,7 @@ class ProbeMixin:
         try:
             async with sse_client(url) as (read_stream, write_stream):
                 async with ClientSession(
-                    read_stream, write_stream, read_timeout_seconds=timedelta(seconds=read_s)
+                    read_stream, write_stream, read_timeout_seconds=read_s
                 ) as session:
                     await session.initialize()
                     tools = await session.list_tools()

--- a/vulnclaw/mcp/lifecycle.py
+++ b/vulnclaw/mcp/lifecycle.py
@@ -8,7 +8,6 @@ import re
 import subprocess
 import time
 from contextlib import suppress
-from datetime import timedelta
 from typing import Any
 from urllib.parse import urlparse
 
@@ -473,7 +472,7 @@ class MCPLifecycleManager(ProbeMixin):
         timeout_s = self._tool_timeout_seconds(config)
         async with stdio_client(server) as (read_stream, write_stream):
             async with ClientSession(
-                read_stream, write_stream, read_timeout_seconds=timedelta(seconds=timeout_s)
+                read_stream, write_stream, read_timeout_seconds=timeout_s
             ) as session:
                 await session.initialize()
                 return await asyncio.wait_for(
@@ -516,7 +515,7 @@ class MCPLifecycleManager(ProbeMixin):
         cm = stdio_client(server)
         read_stream, write_stream = await cm.__aenter__()
         session = ClientSession(
-            read_stream, write_stream, read_timeout_seconds=timedelta(seconds=timeout_s)
+            read_stream, write_stream, read_timeout_seconds=timeout_s
         )
         # 进入 ClientSession 上下文以启动 _receive_loop；否则后续调用读不到响应而卡死。
         try:
@@ -601,7 +600,7 @@ class MCPLifecycleManager(ProbeMixin):
             )
             read_stream, write_stream, _get_session_id = await cm.__aenter__()
             session = ClientSession(
-                read_stream, write_stream, read_timeout_seconds=timedelta(seconds=read_s)
+                read_stream, write_stream, read_timeout_seconds=read_s
             )
             await session.__aenter__()
             await session.initialize()
@@ -675,7 +674,7 @@ class MCPLifecycleManager(ProbeMixin):
             cm = sse_client(url)
             read_stream, write_stream = await cm.__aenter__()
             session = ClientSession(
-                read_stream, write_stream, read_timeout_seconds=timedelta(seconds=read_s)
+                read_stream, write_stream, read_timeout_seconds=read_s
             )
             await session.__aenter__()
             await session.initialize()


### PR DESCRIPTION
Fixes #171.

## Problem

Every `chrome-devtools` / `burp` / stdio / SSE / HTTP MCP tool call crashes on the first request with:

```
TypeError: unsupported operand type(s) for +: 'float' and 'datetime.timedelta'
```

## Root cause

The `mcp` SDK's `ClientSession.__init__` declares `read_timeout_seconds: float | None` — a plain float in **seconds**. But every `ClientSession(...)` construction in the MCP layer wrapped the value in `timedelta(seconds=...)`. That `timedelta` is stored and later flows into `anyio.fail_after()`, which computes `current_time() + delay` (`float + timedelta`) and raises.

Because `vulnclaw doctor` skips probing `npx`-based stdio commands, the doctor check never surfaces this — it only blows up when a real tool call is attempted, so the chrome-devtools/burp integrations are effectively unusable.

Thanks to @abd2508 for the detailed root-cause analysis in #171.

## Fix

Pass the raw float seconds directly instead of wrapping it in `timedelta(...)`, at all `ClientSession` construction sites:

- `vulnclaw/mcp/lifecycle.py` — 4 sites (persistent stdio session + variant, persistent HTTP session, persistent SSE session)
- `vulnclaw/mcp/_probe_mixin.py` — 2 sites (`_async_probe_http_server`, `_async_probe_sse_server`)

```diff
- read_timeout_seconds=timedelta(seconds=timeout_s)
+ read_timeout_seconds=timeout_s
```

`timeout_s` / `read_s` come from `_tool_timeout_seconds()` and are already used as plain seconds elsewhere in the same functions (`asyncio.wait_for(timeout=...)`, `sse_read_timeout=...`), confirming they're numeric seconds. The now-unused `from datetime import timedelta` import is removed from both files.

> Note: the issue references 8 sites across 3 files against the 0.3.6 PyPI layout; on `dev` the `__init__.py` probe copy has been consolidated into `_probe_mixin.py`, so there are 6 sites across 2 files. All are covered here — `grep -r "read_timeout_seconds=timedelta"` returns no remaining matches.

## Testing

- Both modules parse cleanly and `grep` confirms zero remaining `timedelta`-wrapped timeouts.
- I could not run the pytest suite in my environment (project deps not installed locally). The change is mechanical and matches the SDK's `float | None` signature; CI should exercise `tests/mcp/`.