### PR TITLE
fix: add vulnclaw/__main__.py so python -m vulnclaw works

### DIFF
--- a/vulnclaw/__main__.py
+++ b/vulnclaw/__main__.py
@@ -1,0 +1,12 @@
+"""Module entry point so ``python -m vulnclaw`` works.
+
+The Rust ratatui TUI (``tui/``) spawns the Python core via
+``python -m vulnclaw``; without this file that invocation fails with
+"``No module named vulnclaw.__main__``". Keep this in sync with the
+console script entry point (``vulnclaw.cli.main:app`` in pyproject.toml).
+"""
+
+from vulnclaw.cli.main import app
+
+if __name__ == "__main__":
+    app()


### PR DESCRIPTION
## Problem

The Rust ratatui TUI (`tui/`) spawns the Python core via `py -3 -m vulnclaw` (see `tui/src/exec.rs`), but `vulnclaw/__main__.py` does not exist. Every TUI command that invokes the CLI (e.g. `/scan`, `/run`, `/exploit`, `/recon`) crashes immediately with:

```
C:\Python314\python.exe: No module named vulnclaw.__main__; 'vulnclaw' is a package and cannot be directly executed
```

This was introduced with the TUI migration (#186, commit 043b4f3), which added the `python -m vulnclaw` invocation without adding the module entry point.

## Fix

Add a minimal `vulnclaw/__main__.py` that delegates to the Typer app:

```python
from vulnclaw.cli.main import app

if __name__ == "__main__":
    app()
```

This mirrors the console-script entry point `vulnclaw = "vulnclaw.cli.main:app"` in `pyproject.toml`.

## Verification

- `py -3 -m vulnclaw --version` → `0.3.7` (exit 0), from any working directory
- `python -m vulnclaw --help` renders the full CLI help
- `python -m vulnclaw exploit --help` parses correctly (all options incl. `--stream` recognized)
- Only two call sites use `-m vulnclaw` (both in `tui/src/exec.rs`), both now work
