### PR TITLE
fix(ci): point release preflight at tests/meta/test_release.py

### DIFF
--- a/scripts/release_preflight.py
+++ b/scripts/release_preflight.py
@@ -20,7 +20,7 @@ def main() -> int:
     parser.add_argument("--build", action="store_true", help="Also build dist artifacts after tests and typechecks")
     args = parser.parse_args()
 
-    run_step("version-check", [sys.executable, "-m", "pytest", "-q", "tests/test_release.py"])
+    run_step("version-check", [sys.executable, "-m", "pytest", "-q", "tests/meta/test_release.py"])
     run_step("backend-tests", [sys.executable, "-m", "pytest", "-q"])
     npm_cmd = shutil.which("npm") or shutil.which("npm.cmd")
     if not npm_cmd:


### PR DESCRIPTION
## Fix

`scripts/release_preflight.py` hardcoded `tests/test_release.py`, but the test was moved to `tests/meta/test_release.py` during the test-tree reorganization. This caused every `v*` tag push to fail the Release Preflight workflow.

## Change

- Point `version-check` step at `tests/meta/test_release.py`

Verified locally: `python -m pytest -q tests/meta/test_release.py` -> 1 passed.

Also applied to `feature/unclec` (`d360afa`) and `dev` (`6e0687a`).