### PR TITLE
test: spawn the running interpreter instead of a bare `python` (fixes #218)

### DIFF
--- a/tests/agent/test_builtin_tools.py
+++ b/tests/agent/test_builtin_tools.py
@@ -463,10 +463,13 @@ class TestBuiltinPythonExecute:
         assert 'action="api.php"' in result
 
     async def test_shell_command_runs_local_verification_and_returns_full_output(self):
+        import shlex
+        import sys
+
         import vulnclaw.agent.builtin_tools as builtin_tools
 
         agent = DummyAgent()
-        command = 'python -c "print(\'SHELL_OK\')"'
+        command = f"{shlex.quote(sys.executable)} -c \"print('SHELL_OK')\""
 
         result = await builtin_tools.execute_mcp_tool(
             agent,


### PR DESCRIPTION
## Summary

Fixes #218.

`test_shell_command_runs_local_verification_and_returns_full_output` hard-codes `python -c ...`. On a host where the interpreter is only installed as `python3` (macOS default, minimal Linux / Docker), `shell_command` runs it through the shell and it exits 127 (`/bin/sh: python: command not found`), so `pytest -q` fails on a clean checkout — the exact command `CONTRIBUTING.md` §4 tells contributors to run.

This is test-only; the production path already uses `sys.executable` (`report/verifier.py`). The same test suite also already spawns Python the portable way, with a comment explaining why — `tests/mcp/test_mcp_lifecycle.py:674` uses `sys.executable`. This change makes the lagging test consistent with that.

```python
# before
command = 'python -c "print(\'SHELL_OK\')"'
# after
command = f"{shlex.quote(sys.executable)} -c \"print('SHELL_OK')\""
```

`shlex.quote` guards against a space in the interpreter path.

## Testing

- `pytest -q tests/agent/test_builtin_tools.py` — 28 passed (fails on `dev` without this change: `Exit code: 127`).
- `pytest -q` — 1345 passed, 7 skipped (one more pass than `dev`, which has the failing test).
- `ruff check vulnclaw tests` — passes.

CI is unaffected either way because `actions/setup-python` provides a `python` shim; this only bites local contributors.