### PR TITLE
test: spawn the running interpreter instead of a bare `python` (fixes #218)

### DIFF
--- a/tests/agent/test_builtin_tools.py
+++ b/tests/agent/test_builtin_tools.py
@@ -463,10 +463,18 @@ class TestBuiltinPythonExecute:
         assert 'action="api.php"' in result
 
     async def test_shell_command_runs_local_verification_and_returns_full_output(self):
+        import sys
+
         import vulnclaw.agent.builtin_tools as builtin_tools
 
         agent = DummyAgent()
-        command = 'python -c "print(\'SHELL_OK\')"'
+        # Use the running interpreter instead of a bare ``python``, which is not
+        # on PATH where the interpreter is installed only as ``python3`` (macOS
+        # default, minimal Linux/Docker). The path is left unquoted so the shell
+        # token is a bare executable, exactly like the previous ``python`` — this
+        # keeps the Windows ``cmd`` command line unchanged in shape (POSIX single
+        # quotes from ``shlex.quote`` break ``cmd``; hosted CI paths have no spaces).
+        command = f"{sys.executable} -c \"print('SHELL_OK')\""
 
         result = await builtin_tools.execute_mcp_tool(
             agent,


### PR DESCRIPTION
## Summary

Fixes #218. (Reopens #219, which was closed after the Windows CI legs failed — this revision fixes that; see below.)

`test_shell_command_runs_local_verification_and_returns_full_output` hard-codes `python -c ...`. Where the interpreter is only installed as `python3` (macOS default, minimal Linux/Docker), `shell_command` runs it through the shell and it exits 127 (`python: command not found`), so `pytest -q` fails on a clean checkout — the exact command `CONTRIBUTING.md` §4 tells contributors to run. Production code is unaffected (`report/verifier.py` already uses `sys.executable`).

```python
# before
command = 'python -c "print(\'SHELL_OK\')"'
# after
command = f"{sys.executable} -c \"print('SHELL_OK')\""
```

## Why `sys.executable` is left unquoted

The first revision used `shlex.quote(sys.executable)`. `shlex.quote` is POSIX-only: on Windows it wraps the backslash path in **single** quotes, which `cmd` rejects (`The filename, directory name, or volume label syntax is incorrect.`) — this is what failed the `windows-latest` CI legs.

Leaving the path unquoted keeps the shell token a bare executable, exactly like the previous `python`, so the Windows `cmd.exe /c` command line is unchanged in shape — only the token differs (`python` → full path). Verified with `subprocess.list2cmdline(["cmd.exe", "/c", command])`:

```
before (passed on Windows): cmd.exe /c "python -c \"print('SHELL_OK')\""
after  (this revision):     cmd.exe /c "C:\...\python.exe -c \"print('SHELL_OK')\""
```

Hosted CI interpreter paths contain no spaces, so the bare token resolves on every matrix leg. This mirrors the portable spawn already used in `tests/mcp/test_mcp_lifecycle.py:674` (`sys.executable`).

## Testing

- `pytest -q tests/agent/test_builtin_tools.py` — 28 passed (fails on `dev`: `Exit code: 127`).
- `pytest -q` — full suite green.
- `ruff check vulnclaw tests` — passes.
- Windows command-line shape confirmed identical to the previously-passing form via `list2cmdline` (above).