### PR TITLE
fix(mcp): adapt session timeouts to SDK duration type

### DIFF
--- a/tests/mcp/test_mcp_lifecycle.py
+++ b/tests/mcp/test_mcp_lifecycle.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from datetime import timedelta
 
 import pytest
 
@@ -13,6 +14,19 @@ from vulnclaw.mcp.registry import HealthStatus
 
 def _manager() -> MCPLifecycleManager:
     return MCPLifecycleManager(VulnClawConfig())
+
+
+def test_client_session_timeout_adapts_config_seconds_to_sdk_timedelta():
+    """The MCP SDK accepts ``timedelta``, while transport config stores milliseconds."""
+    cfg = MCPServerConfig(
+        name="timeout-probe",
+        transport={"type": "stdio", "command": "noop", "tool_timeout": 1500},
+    )
+
+    timeout = _manager()._client_session_timeout(cfg)
+
+    assert isinstance(timeout, timedelta)
+    assert timeout.total_seconds() == 1.5
 
 
 class _FakeProc:

--- a/vulnclaw/mcp/_probe_mixin.py
+++ b/vulnclaw/mcp/_probe_mixin.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import asyncio
 import concurrent.futures
+from datetime import timedelta
 from typing import Any
 from urllib.parse import urlparse
 
@@ -195,7 +196,9 @@ class ProbeMixin:
                 url, headers=headers, timeout=connect_s, sse_read_timeout=read_s
             ) as (read_stream, write_stream, _get_session_id):
                 async with ClientSession(
-                    read_stream, write_stream, read_timeout_seconds=read_s
+                    read_stream,
+                    write_stream,
+                    read_timeout_seconds=self._client_session_timeout(config),
                 ) as session:
                     await session.initialize()
                     tools = await session.list_tools()
@@ -221,11 +224,12 @@ class ProbeMixin:
         self, config: MCPServerConfig
     ) -> tuple[bool, str, list[dict[str, Any]]]:
         url = config.transport.url or ""
-        read_s = self._tool_timeout_seconds(config)
         try:
             async with sse_client(url) as (read_stream, write_stream):
                 async with ClientSession(
-                    read_stream, write_stream, read_timeout_seconds=read_s
+                    read_stream,
+                    write_stream,
+                    read_timeout_seconds=self._client_session_timeout(config),
                 ) as session:
                     await session.initialize()
                     tools = await session.list_tools()
@@ -290,6 +294,11 @@ class ProbeMixin:
         if not raw or raw <= 0:
             return 300.0
         return float(raw) / 1000.0
+
+    @classmethod
+    def _client_session_timeout(cls, config: MCPServerConfig) -> timedelta:
+        """Adapt VulnClaw's numeric timeout to the MCP SDK's duration type."""
+        return timedelta(seconds=cls._tool_timeout_seconds(config))
 
     async def _async_probe_stdio_server(
         self, config: MCPServerConfig

--- a/vulnclaw/mcp/lifecycle.py
+++ b/vulnclaw/mcp/lifecycle.py
@@ -472,7 +472,9 @@ class MCPLifecycleManager(ProbeMixin):
         timeout_s = self._tool_timeout_seconds(config)
         async with stdio_client(server) as (read_stream, write_stream):
             async with ClientSession(
-                read_stream, write_stream, read_timeout_seconds=timeout_s
+                read_stream,
+                write_stream,
+                read_timeout_seconds=self._client_session_timeout(config),
             ) as session:
                 await session.initialize()
                 return await asyncio.wait_for(
@@ -510,12 +512,13 @@ class MCPLifecycleManager(ProbeMixin):
             args=transport.args or [],
             env=transport.env,
         )
-        timeout_s = self._tool_timeout_seconds(config)
 
         cm = stdio_client(server)
         read_stream, write_stream = await cm.__aenter__()
         session = ClientSession(
-            read_stream, write_stream, read_timeout_seconds=timeout_s
+            read_stream,
+            write_stream,
+            read_timeout_seconds=self._client_session_timeout(config),
         )
         # 进入 ClientSession 上下文以启动 _receive_loop；否则后续调用读不到响应而卡死。
         try:
@@ -600,7 +603,9 @@ class MCPLifecycleManager(ProbeMixin):
             )
             read_stream, write_stream, _get_session_id = await cm.__aenter__()
             session = ClientSession(
-                read_stream, write_stream, read_timeout_seconds=read_s
+                read_stream,
+                write_stream,
+                read_timeout_seconds=self._client_session_timeout(config),
             )
             await session.__aenter__()
             await session.initialize()
@@ -666,7 +671,6 @@ class MCPLifecycleManager(ProbeMixin):
         url = config.transport.url or ""
         if not url:
             raise RuntimeError(f"sse transport for {server_name} is missing url")
-        read_s = self._tool_timeout_seconds(config)
 
         cm = None
         session = None
@@ -674,7 +678,9 @@ class MCPLifecycleManager(ProbeMixin):
             cm = sse_client(url)
             read_stream, write_stream = await cm.__aenter__()
             session = ClientSession(
-                read_stream, write_stream, read_timeout_seconds=read_s
+                read_stream,
+                write_stream,
+                read_timeout_seconds=self._client_session_timeout(config),
             )
             await session.__aenter__()
             await session.initialize()


### PR DESCRIPTION
Fixes #171.

## Problem

Every `ClientSession` in `vulnclaw/mcp/` is constructed with a raw float:

```python
read_s = self._tool_timeout_seconds(config)
async with ClientSession(
    read_stream, write_stream, read_timeout_seconds=read_s
) as session:
```

`ClientSession.read_timeout_seconds` is typed `datetime.timedelta | None` in the MCP SDK, and the SDK adds it to a `datetime` while waiting on a response. Passing a float means the first tool call over that session raises:

```
TypeError: unsupported operand type(s) for +: 'float' and 'datetime.timedelta'
```

The obvious diagnosis is wrong: this is *not* a bug in the chrome-devtools or burp MCP servers, and it is not a transport problem. It reproduces on any server whose session survives long enough for a `tools/call`, regardless of transport — the crash is on our side of the client, in the argument type.

## Why it did not surface earlier

Probe and `list_tools` paths complete inside the SDK's own request handling and never hit the arithmetic, so `vulnclaw mcp probe` and server registration both pass cleanly. The failure only appears once an agent actually invokes a tool, which is why the servers look healthy right up to the point they are used.

## Fix

Add `ProbeMixin._client_session_timeout()`, which adapts the configured millisecond timeout to the SDK's duration type, and route all six `ClientSession` construction sites through it:

- `_probe_mixin.py` — streamable-http probe, sse probe
- `lifecycle.py` — stdio one-shot, stdio long-lived, streamable-http long-lived, sse long-lived

The conversion sits next to `_tool_timeout_seconds()` so the millisecond-to-seconds-to-timedelta chain stays in one place, rather than each call site doing its own `timedelta(seconds=...)` wrap. `sse_read_timeout` on the transport clients still takes a float — that parameter is genuinely typed as seconds and is deliberately left alone.

## Blast radius if unfixed

Any MCP server configured through VulnClaw is unusable for tool calls: the agent registers the server, advertises its tools to the model, and then fails on first invocation with a type error that reads as an internal crash rather than a configuration problem.

## Verification

```
ruff check vulnclaw tests   # All checks passed
pytest -q                   # 1426 passed, 1 skipped
```

New test `test_client_session_timeout_adapts_config_seconds_to_sdk_timedelta` in `tests/mcp/test_mcp_lifecycle.py` asserts a `tool_timeout` of 1500 ms yields `timedelta(seconds=1.5)`.

No frontend files are touched.
