### PR TITLE
fix(mcp): bound session reads locally instead of via SDK timeout type

### DIFF
--- a/tests/mcp/test_mcp_lifecycle.py
+++ b/tests/mcp/test_mcp_lifecycle.py
@@ -15,6 +15,53 @@ def _manager() -> MCPLifecycleManager:
     return MCPLifecycleManager(VulnClawConfig())
 
 
+class TestSessionTimeouts:
+    """MCP session timeouts are enforced locally, not via the SDK's read_timeout_seconds.
+
+    The SDK has typed ``ClientSession.read_timeout_seconds`` as both float-seconds
+    and ``datetime.timedelta`` across releases, so passing either one crashes on
+    the version that expects the other (issue #171). VulnClaw passes neither.
+    """
+
+    def test_no_client_session_passes_read_timeout_seconds(self):
+        from pathlib import Path
+
+        import vulnclaw.mcp as mcp_pkg
+
+        offenders = []
+        for path in Path(mcp_pkg.__file__).parent.glob("*.py"):
+            for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+                stripped = line.strip()
+                if stripped.startswith("#"):
+                    continue
+                if "read_timeout_seconds=" in stripped:
+                    offenders.append(f"{path.name}:{lineno}")
+        assert offenders == [], (
+            "ClientSession must not receive read_timeout_seconds; bound the call with "
+            f"asyncio.wait_for instead. Offending sites: {offenders}"
+        )
+
+    def test_attached_server_call_times_out_without_sdk_timeout(self, monkeypatch):
+        cfg = VulnClawConfig()
+        cfg.mcp.servers["slow"] = MCPServerConfig(
+            name="slow",
+            transport={"type": "stdio", "command": "noop", "tool_timeout": 10},
+        )
+        m = MCPLifecycleManager(cfg)
+
+        class _HangingSession:
+            async def call_tool(self, name, arguments=None):
+                await asyncio.sleep(60)
+
+        async def _fake_get_or_create_session(server_name):
+            return _HangingSession()
+
+        monkeypatch.setattr(m, "_get_or_create_session", _fake_get_or_create_session)
+
+        with pytest.raises(asyncio.TimeoutError):
+            asyncio.run(m._call_attached_server("slow", "anything", {}))
+
+
 class _FakeProc:
     """Minimal subprocess.Popen stand-in for liveness/termination tests."""
 

--- a/vulnclaw/mcp/_probe_mixin.py
+++ b/vulnclaw/mcp/_probe_mixin.py
@@ -194,9 +194,10 @@ class ProbeMixin:
             async with streamablehttp_client(
                 url, headers=headers, timeout=connect_s, sse_read_timeout=read_s
             ) as (read_stream, write_stream, _get_session_id):
-                async with ClientSession(
-                    read_stream, write_stream, read_timeout_seconds=read_s
-                ) as session:
+                # read_timeout_seconds is deliberately left unset: the SDK has
+                # typed it as both float-seconds and timedelta across releases,
+                # so the probe is bounded by _run_probe's asyncio.wait_for instead.
+                async with ClientSession(read_stream, write_stream) as session:
                     await session.initialize()
                     tools = await session.list_tools()
                     tool_defs = self._normalize_mcp_tools(getattr(tools, "tools", []) or [])
@@ -221,12 +222,10 @@ class ProbeMixin:
         self, config: MCPServerConfig
     ) -> tuple[bool, str, list[dict[str, Any]]]:
         url = config.transport.url or ""
-        read_s = self._tool_timeout_seconds(config)
         try:
             async with sse_client(url) as (read_stream, write_stream):
-                async with ClientSession(
-                    read_stream, write_stream, read_timeout_seconds=read_s
-                ) as session:
+                # Bounded by _run_probe's asyncio.wait_for; see _async_probe_http_server.
+                async with ClientSession(read_stream, write_stream) as session:
                     await session.initialize()
                     tools = await session.list_tools()
                     tool_defs = self._normalize_mcp_tools(getattr(tools, "tools", []) or [])

--- a/vulnclaw/mcp/lifecycle.py
+++ b/vulnclaw/mcp/lifecycle.py
@@ -470,11 +470,13 @@ class MCPLifecycleManager(ProbeMixin):
         )
 
         timeout_s = self._tool_timeout_seconds(config)
+        startup_s = self._startup_timeout_seconds(config)
         async with stdio_client(server) as (read_stream, write_stream):
-            async with ClientSession(
-                read_stream, write_stream, read_timeout_seconds=timeout_s
-            ) as session:
-                await session.initialize()
+            # read_timeout_seconds is deliberately unset: the SDK has typed it as
+            # both float-seconds and timedelta across releases, so every await
+            # below carries its own asyncio.wait_for instead.
+            async with ClientSession(read_stream, write_stream) as session:
+                await asyncio.wait_for(session.initialize(), timeout=startup_s)
                 return await asyncio.wait_for(
                     session.call_tool(tool_name, arguments=arguments), timeout=timeout_s
                 )
@@ -510,17 +512,17 @@ class MCPLifecycleManager(ProbeMixin):
             args=transport.args or [],
             env=transport.env,
         )
-        timeout_s = self._tool_timeout_seconds(config)
+        startup_s = self._startup_timeout_seconds(config)
 
         cm = stdio_client(server)
         read_stream, write_stream = await cm.__aenter__()
-        session = ClientSession(
-            read_stream, write_stream, read_timeout_seconds=timeout_s
-        )
+        # read_timeout_seconds is deliberately unset; per-call timeouts are applied
+        # locally via asyncio.wait_for (see _call_attached_server).
+        session = ClientSession(read_stream, write_stream)
         # 进入 ClientSession 上下文以启动 _receive_loop；否则后续调用读不到响应而卡死。
         try:
             await session.__aenter__()
-            await session.initialize()
+            await asyncio.wait_for(session.initialize(), timeout=startup_s)
         except BaseException:
             with _suppress_cleanup_errors():
                 await session.__aexit__(None, None, None)
@@ -599,11 +601,11 @@ class MCPLifecycleManager(ProbeMixin):
                 url, headers=headers, timeout=connect_s, sse_read_timeout=read_s
             )
             read_stream, write_stream, _get_session_id = await cm.__aenter__()
-            session = ClientSession(
-                read_stream, write_stream, read_timeout_seconds=read_s
-            )
+            # read_timeout_seconds is deliberately unset; per-call timeouts are applied
+            # locally via asyncio.wait_for (see _call_attached_server).
+            session = ClientSession(read_stream, write_stream)
             await session.__aenter__()
-            await session.initialize()
+            await asyncio.wait_for(session.initialize(), timeout=connect_s)
         except BaseException as exc:
             # Clean up partial state
             if session is not None:
@@ -624,7 +626,7 @@ class MCPLifecycleManager(ProbeMixin):
 
         # 首次连接时发现真实工具并替换启动时注册的静态占位工具
         try:
-            tools = await session.list_tools()
+            tools = await asyncio.wait_for(session.list_tools(), timeout=read_s)
             tool_defs = self._normalize_mcp_tools(getattr(tools, "tools", []) or [])
             if tool_defs:
                 self._register_runtime_tools(server_name, tool_defs)
@@ -667,17 +669,18 @@ class MCPLifecycleManager(ProbeMixin):
         if not url:
             raise RuntimeError(f"sse transport for {server_name} is missing url")
         read_s = self._tool_timeout_seconds(config)
+        connect_s = self._startup_timeout_seconds(config)
 
         cm = None
         session = None
         try:
             cm = sse_client(url)
             read_stream, write_stream = await cm.__aenter__()
-            session = ClientSession(
-                read_stream, write_stream, read_timeout_seconds=read_s
-            )
+            # read_timeout_seconds is deliberately unset; per-call timeouts are applied
+            # locally via asyncio.wait_for (see _call_attached_server).
+            session = ClientSession(read_stream, write_stream)
             await session.__aenter__()
-            await session.initialize()
+            await asyncio.wait_for(session.initialize(), timeout=connect_s)
         except BaseException as exc:
             if session is not None:
                 with _suppress_cleanup_errors():
@@ -693,7 +696,7 @@ class MCPLifecycleManager(ProbeMixin):
             raise RuntimeError(f"sse session for {server_name} failed: {detail}") from None
 
         try:
-            tools = await session.list_tools()
+            tools = await asyncio.wait_for(session.list_tools(), timeout=read_s)
             tool_defs = self._normalize_mcp_tools(getattr(tools, "tools", []) or [])
             if tool_defs:
                 self._register_runtime_tools(server_name, tool_defs)


### PR DESCRIPTION
Follow-up to #188. Fixes #171.

## The fix in #188 is right, and it is also version-dependent

#188 removed the `timedelta(...)` wrappers and passed `read_timeout_seconds` as a raw float. For the SDK release the reporter of #171 was running, that is correct: the value reached `anyio.fail_after()`, which computes `current_time() + delay`, so a `timedelta` produced

```
TypeError: unsupported operand type(s) for +: 'float' and 'datetime.timedelta'
```

On current releases the parameter has the opposite contract. Checked against `mcp` 1.28.1:

```python
# mcp/client/session.py
read_timeout_seconds: datetime.timedelta | None = None

# mcp/shared/session.py:286-288
if request_read_timeout_seconds is not None:
    timeout = request_read_timeout_seconds.total_seconds()
elif self._session_read_timeout_seconds is not None:
    timeout = self._session_read_timeout_seconds.total_seconds()
```

A float there raises `AttributeError: 'float' object has no attribute 'total_seconds'` on the first tool call — the same user-visible symptom #171 describes, from the opposite cause.

`mcp` is not pinned in `pyproject.toml`; it is picked up from whatever the user has installed. So neither the float form nor the `timedelta` form is correct for all installs, and swapping between them just moves the breakage from one half of the userbase to the other. I nearly opened exactly that swap-back PR before checking the installed SDK — closing it in favour of this.

## Approach

Stop passing `read_timeout_seconds` entirely and bound every SDK await with `asyncio.wait_for`, which is the timeout mechanism most call sites already used:

- `lifecycle.py:479` — `call_tool` on the one-shot stdio path, already wrapped with `tool_timeout`
- `lifecycle.py:1650` — `call_tool` in `_call_attached_server`, already wrapped with `tool_timeout`
- `lifecycle.py:535` — `list_tools` on the persistent stdio path, already wrapped
- `_probe_mixin.py:253,260` — both probe coroutines, already wrapped by `_run_probe`

`_async_probe_stdio_server` has always constructed `ClientSession(read_stream, write_stream)` with no SDK timeout, so this makes the layer internally consistent rather than introducing a new convention.

Awaits that had *no* bound before and now have one:

| Site | Bound by |
|---|---|
| `session.initialize()` — one-shot stdio, persistent stdio, persistent HTTP, persistent SSE | `startup_timeout` |
| `session.list_tools()` — persistent HTTP, persistent SSE | `tool_timeout` |

The two `list_tools()` calls sat inside bare `try/except Exception: pass` blocks, so an unresponsive server hung session setup indefinitely with no error — that was latent before this PR and is fixed here.

`sse_read_timeout` on the transport clients still takes a float; that parameter is genuinely typed as seconds and is untouched.

## Blast radius if left as-is

Anyone on an SDK where `read_timeout_seconds` is `timedelta`-typed — which includes current PyPI `mcp` — cannot make a single MCP tool call. The server registers, its tools are advertised to the model, and the first invocation fails with an `AttributeError` that reads as an internal VulnClaw crash rather than a version mismatch.

## Tests

`TestSessionTimeouts` in `tests/mcp/test_mcp_lifecycle.py`:

- `test_no_client_session_passes_read_timeout_seconds` scans `vulnclaw/mcp/*.py` for non-comment `read_timeout_seconds=` and fails on any hit. This is the regression guard that keeps the codebase from oscillating between the two broken forms as the SDK moves.
- `test_attached_server_call_times_out_without_sdk_timeout` drives `_call_attached_server` against a session whose `call_tool` sleeps for 60s with a 10 ms configured `tool_timeout`, and asserts `asyncio.TimeoutError` — proving the local bound is what enforces the timeout now.

```
ruff check vulnclaw tests   # All checks passed
pytest -q                   # 1427 passed, 1 skipped
```

No frontend files are touched.
