### PR TITLE
feat(hackerone): deterministic scope loader + explicit-launch skill body

### DIFF
--- a/tests/agent/test_agent.py
+++ b/tests/agent/test_agent.py
@@ -1073,7 +1073,10 @@ class TestAgentCore:
             user_input="Use VulnClaw skill secknowledge-skill. test this target"
         )
         assert context is not None
-        assert "optional reference material" in context
+        # Explicit invocation injects the skill body as the active workflow,
+        # not the optional reference index used for keyword/fallback routing.
+        assert "Active skill (explicit invocation)" in context
+        assert "optional reference material only" not in context.lower()
         assert "secknowledge-skill" in context
 
     def test_build_openai_tools_includes_skill_ref(self):

--- a/tests/agent/test_hackerone_scope.py
+++ b/tests/agent/test_hackerone_scope.py
@@ -9,9 +9,9 @@ from typing import Any
 import pytest
 
 from vulnclaw.agent.hackerone_scope import (
+    MAX_PAGES,
     execute_hackerone_scope,
     extract_program_handle,
-    MAX_PAGES,
     fetch_program_scope,
     format_scope_report,
 )

--- a/tests/agent/test_hackerone_scope.py
+++ b/tests/agent/test_hackerone_scope.py
@@ -11,6 +11,7 @@ import pytest
 from vulnclaw.agent.hackerone_scope import (
     execute_hackerone_scope,
     extract_program_handle,
+    MAX_PAGES,
     fetch_program_scope,
     format_scope_report,
 )
@@ -122,6 +123,40 @@ class TestFetchProgramScope:
         report = format_scope_report(bundle)
         assert "Starting recon on *.crypto.com" in report
         assert "blog.crypto.com" in report
+
+    def test_truncated_pagination_raises_instead_of_returning_partial_scope(self):
+        """Silently stopping at MAX_PAGES would hide out-of-scope assets."""
+        calls = {"n": 0}
+
+        def opener(_request: Any, timeout: float = 0) -> _FakeResponse:
+            calls["n"] += 1
+            return _FakeResponse(
+                _team_payload(
+                    [
+                        {
+                            "id": f"gid://hackerone/StructuredScope/{calls['n']}",
+                            "asset_type": "URL",
+                            "asset_identifier": f"host{calls['n']}.crypto.com",
+                            "eligible_for_submission": True,
+                            "eligible_for_bounty": True,
+                        }
+                    ],
+                    has_next=True,
+                )
+            )
+
+        with pytest.raises(RuntimeError, match="partial scope"):
+            fetch_program_scope("crypto", opener=opener)
+        assert calls["n"] == MAX_PAGES
+
+    def test_missing_cursor_with_more_pages_raises(self):
+        def opener(_request: Any, timeout: float = 0) -> _FakeResponse:
+            payload = _team_payload([], has_next=True)
+            payload["data"]["team"]["structured_scopes"]["pageInfo"]["endCursor"] = None
+            return _FakeResponse(payload)
+
+        with pytest.raises(RuntimeError, match="no pagination cursor"):
+            fetch_program_scope("crypto", opener=opener)
 
     def test_missing_team_raises(self):
         def opener(_request: Any, timeout: float = 0) -> _FakeResponse:

--- a/tests/agent/test_hackerone_scope.py
+++ b/tests/agent/test_hackerone_scope.py
@@ -1,0 +1,177 @@
+"""Tests for HackerOne structured-scope fetch and explicit skill injection."""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+from typing import Any
+
+import pytest
+
+from vulnclaw.agent.hackerone_scope import (
+    execute_hackerone_scope,
+    extract_program_handle,
+    fetch_program_scope,
+    format_scope_report,
+)
+
+
+class _FakeResponse:
+    def __init__(self, body: dict[str, Any], status: int = 200) -> None:
+        self._raw = json.dumps(body).encode("utf-8")
+        self.status = status
+
+    def read(self) -> bytes:
+        return self._raw
+
+    def getcode(self) -> int:
+        return self.status
+
+    def __enter__(self) -> "_FakeResponse":
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        return None
+
+
+def _team_payload(nodes: list[dict[str, Any]], *, has_next: bool = False) -> dict[str, Any]:
+    return {
+        "data": {
+            "team": {
+                "id": "gid://hackerone/Team/1",
+                "handle": "crypto",
+                "name": "Crypto.com",
+                "structured_scopes": {
+                    "total_count": len(nodes),
+                    "pageInfo": {
+                        "hasNextPage": has_next,
+                        "endCursor": "cursor-1" if has_next else None,
+                    },
+                    "nodes": nodes,
+                },
+            }
+        }
+    }
+
+
+class TestExtractHandle:
+    def test_from_policy_scopes_url(self):
+        assert (
+            extract_program_handle("https://hackerone.com/crypto/policy_scopes")
+            == "crypto"
+        )
+
+    def test_from_quoted_url(self):
+        assert (
+            extract_program_handle('"https://hackerone.com/example/policy_scopes"')
+            == "example"
+        )
+
+    def test_bare_handle(self):
+        assert extract_program_handle("security") == "security"
+
+    def test_rejects_directory(self):
+        with pytest.raises(ValueError):
+            extract_program_handle("https://hackerone.com/directory")
+
+
+class TestFetchProgramScope:
+    def test_splits_in_and_out_of_scope(self):
+        nodes = [
+            {
+                "asset_identifier": "*.crypto.com",
+                "asset_type": "WILDCARD",
+                "eligible_for_submission": True,
+                "eligible_for_bounty": True,
+                "max_severity": "critical",
+                "instruction": "main assets",
+            },
+            {
+                "asset_identifier": "https://crypto.com/exchange",
+                "asset_type": "URL",
+                "eligible_for_submission": True,
+                "eligible_for_bounty": True,
+                "max_severity": "critical",
+                "instruction": "",
+            },
+            {
+                "asset_identifier": "blog.crypto.com",
+                "asset_type": "URL",
+                "eligible_for_submission": False,
+                "eligible_for_bounty": False,
+                "max_severity": "none",
+                "instruction": "",
+            },
+        ]
+
+        def opener(_request: Any, timeout: float = 0) -> _FakeResponse:
+            return _FakeResponse(_team_payload(nodes))
+
+        bundle = fetch_program_scope(
+            "https://hackerone.com/crypto/policy_scopes", opener=opener
+        )
+        assert bundle.handle == "crypto"
+        assert bundle.program_name == "Crypto.com"
+        assert len(bundle.in_scope) == 2
+        assert len(bundle.out_of_scope) == 1
+        assert bundle.out_of_scope[0].identifier == "blog.crypto.com"
+        first = bundle.first_direct_asset()
+        assert first is not None
+        assert first.identifier == "*.crypto.com"
+
+        report = format_scope_report(bundle)
+        assert "Starting recon on *.crypto.com" in report
+        assert "blog.crypto.com" in report
+
+    def test_missing_team_raises(self):
+        def opener(_request: Any, timeout: float = 0) -> _FakeResponse:
+            return _FakeResponse({"data": {"team": None}})
+
+        with pytest.raises(RuntimeError, match="not found"):
+            fetch_program_scope("ghost-program", opener=opener)
+
+    def test_execute_surfaces_paste_suggestion_on_failure(self):
+        def boom(_request: Any, timeout: float = 0) -> Any:
+            raise urllib.error.URLError("offline")
+
+        # Patch at urllib level through execute path by patching fetch.
+        # Use direct execute with monkeypatched fetch via args only after
+        # extract fails... better: stub open via broken domain handle using
+        # monkeypatch on module.
+        from vulnclaw.agent import hackerone_scope as mod
+
+        original = mod.fetch_program_scope
+
+        def fail(seed: str, **kwargs: Any) -> Any:
+            raise RuntimeError("network down")
+
+        mod.fetch_program_scope = fail  # type: ignore[assignment]
+        try:
+            out = execute_hackerone_scope({"program": "crypto"})
+        finally:
+            mod.fetch_program_scope = original  # type: ignore[assignment]
+        assert out.startswith("[!] failed to load HackerOne scope:")
+        assert "paste" in out.lower()
+
+
+class TestExplicitSkillInjection:
+    def test_explicit_hackerone_injects_skill_body(self):
+        from vulnclaw.agent.skill_context import get_active_skill_context
+
+        ctx = get_active_skill_context(
+            "Use VulnClaw skill hackerone. https://hackerone.com/crypto/policy_scopes"
+        )
+        assert ctx is not None
+        assert "Active skill (explicit invocation)" in ctx
+        assert "hackerone_scope" in ctx
+        assert "Never treat `hackerone.com` as the recon/pentest target" in ctx
+        # optional-index disclaimer must not apply to explicit launch
+        assert "optional reference material only" not in ctx.lower()
+
+    def test_keyword_match_still_optional_index_only(self):
+        from vulnclaw.agent.skill_context import get_active_skill_context
+
+        ctx = get_active_skill_context("对这个APP做逆向分析")
+        assert ctx is not None
+        assert "optional reference material only" in ctx.lower()
+        assert "Active skill (explicit invocation)" not in ctx

--- a/tests/skills/test_skills.py
+++ b/tests/skills/test_skills.py
@@ -145,6 +145,23 @@ class TestSkillLoader:
         skill = load_skill_by_name("pentest-flow")
         assert skill.get("references", []) == []
 
+    def test_hackerone_skill_and_reference_are_english(self):
+        """The HackerOne workflow should honor the English UI language."""
+        from vulnclaw.skills.loader import load_skill_by_name, load_skill_reference
+
+        skill = load_skill_by_name("hackerone")
+        reference = load_skill_reference("hackerone", "hackerone-report-and-scope.md")
+
+        assert skill is not None
+        assert reference is not None
+        assert not any("\u4e00" <= char <= "\u9fff" for char in skill["content"])
+        assert not any("\u4e00" <= char <= "\u9fff" for char in reference)
+        assert "Scope defined:" in skill["content"]
+        assert "Automatically begin recon" in skill["content"]
+        assert "Do not load or print the reference document during startup" in skill["content"]
+        assert "hackerone_scope" in skill["content"]
+        assert "Never treat `hackerone.com` as the recon/pentest target" in skill["content"]
+
     def test_load_skill_reference(self):
         """Test loading a specific reference file from a skill."""
         from vulnclaw.skills.loader import load_skill_reference

--- a/vulnclaw/agent/hackerone_scope.py
+++ b/vulnclaw/agent/hackerone_scope.py
@@ -122,6 +122,7 @@ def fetch_program_scope(
     program_id = ""
     total_count = 0
     after: str | None = None
+    complete = False
     open_url = opener or urllib.request.urlopen
 
     for _ in range(MAX_PAGES):
@@ -192,10 +193,23 @@ def fetch_program_scope(
 
         page_info = scopes.get("pageInfo") or {}
         if not page_info.get("hasNextPage"):
+            complete = True
             break
         after = page_info.get("endCursor")
         if not after:
-            break
+            raise RuntimeError(
+                f"HackerOne reported more scope pages for {handle!r} but returned "
+                f"no pagination cursor after {len(nodes)} assets"
+            )
+
+    # An incomplete scope is never safe to act on: a missing out-of-scope row
+    # can send recon at an asset the program forbids.
+    if not complete:
+        raise RuntimeError(
+            f"HackerOne scope for {handle!r} exceeds {MAX_PAGES} pages of "
+            f"{page_size} ({len(nodes)} assets read, total_count={total_count}); "
+            "refusing to return a partial scope"
+        )
 
     return _bundle_from_nodes(
         handle=handle,

--- a/vulnclaw/agent/hackerone_scope.py
+++ b/vulnclaw/agent/hackerone_scope.py
@@ -1,0 +1,378 @@
+"""Fetch and normalize HackerOne program structured scope via public GraphQL.
+
+HackerOne program pages are SPAs: HTML fetches return an empty app shell. Scope
+rows load from ``https://hackerone.com/graphql`` (or authenticated
+``api.hackerone.com``). This module is the deterministic path for the
+``hackerone`` skill so agents do not reverse-engineer HackerOne's frontend.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import urllib.error
+import urllib.request
+from dataclasses import asdict, dataclass, field
+from typing import Any
+from urllib.parse import urlparse
+
+GRAPHQL_URL = "https://hackerone.com/graphql"
+DEFAULT_PAGE_SIZE = 100
+MAX_PAGES = 20
+REQUEST_TIMEOUT_S = 30.0
+
+_HANDLE_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$")
+
+_GRAPHQL_QUERY = """
+query VulnClawStructuredScopes($handle: String!, $first: Int!, $after: String) {
+  team(handle: $handle) {
+    id
+    handle
+    name
+    structured_scopes(first: $first, after: $after, archived: false) {
+      total_count
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      nodes {
+        id
+        asset_type
+        asset_identifier
+        instruction
+        eligible_for_bounty
+        eligible_for_submission
+        max_severity
+      }
+    }
+  }
+}
+""".strip()
+
+# Asset types pentest-flow can drive without a specialized workflow.
+_DIRECT_TYPES = frozenset({"URL", "WILDCARD", "DOMAIN"})
+
+
+@dataclass
+class ScopeAsset:
+    identifier: str
+    asset_type: str
+    eligible_for_submission: bool
+    eligible_for_bounty: bool
+    max_severity: str = ""
+    instruction: str = ""
+
+    @property
+    def direct_testable(self) -> bool:
+        return self.asset_type.upper() in _DIRECT_TYPES and self.eligible_for_submission
+
+
+@dataclass
+class ScopeBundle:
+    handle: str
+    program_name: str = ""
+    program_id: str = ""
+    source: str = "hackerone_graphql"
+    in_scope: list[ScopeAsset] = field(default_factory=list)
+    out_of_scope: list[ScopeAsset] = field(default_factory=list)
+    total_count: int = 0
+    errors: list[str] = field(default_factory=list)
+
+    def first_direct_asset(self) -> ScopeAsset | None:
+        for asset in self.in_scope:
+            if asset.direct_testable:
+                return asset
+        return None
+
+
+def extract_program_handle(seed: str) -> str:
+    """Extract a HackerOne program handle from a URL, path, or bare handle."""
+    raw = (seed or "").strip().strip("\"'")
+    if not raw:
+        raise ValueError("empty HackerOne program seed")
+
+    candidate = raw
+    if "://" in raw or raw.startswith("//") or "hackerone.com" in raw.lower():
+        parsed = urlparse(raw if "://" in raw else f"https://{raw.lstrip('/')}")
+        path = (parsed.path or "").strip("/")
+        if not path:
+            raise ValueError(f"no program handle in URL path: {seed!r}")
+        candidate = path.split("/")[0]
+
+    candidate = candidate.strip().strip("/")
+    if candidate.lower() in {"opportunities", "directory", "hacktivity", "users"}:
+        raise ValueError(f"not a program handle: {candidate!r}")
+    if not _HANDLE_RE.match(candidate):
+        raise ValueError(f"invalid HackerOne program handle: {candidate!r}")
+    return candidate
+
+
+def fetch_program_scope(
+    seed: str,
+    *,
+    page_size: int = DEFAULT_PAGE_SIZE,
+    timeout_s: float = REQUEST_TIMEOUT_S,
+    opener: Any | None = None,
+) -> ScopeBundle:
+    """Fetch structured scope for a program seed (URL or handle)."""
+    handle = extract_program_handle(seed)
+    page_size = max(1, min(int(page_size or DEFAULT_PAGE_SIZE), 200))
+    nodes: list[dict[str, Any]] = []
+    program_name = ""
+    program_id = ""
+    total_count = 0
+    after: str | None = None
+    open_url = opener or urllib.request.urlopen
+
+    for _ in range(MAX_PAGES):
+        payload = {
+            "operationName": "VulnClawStructuredScopes",
+            "variables": {
+                "handle": handle,
+                "first": page_size,
+                "after": after,
+            },
+            "query": _GRAPHQL_QUERY,
+        }
+        body = json.dumps(payload).encode("utf-8")
+        request = urllib.request.Request(
+            GRAPHQL_URL,
+            data=body,
+            method="POST",
+            headers={
+                "Content-Type": "application/json",
+                "Accept": "application/json",
+                "User-Agent": "VulnClaw/hackerone_scope",
+            },
+        )
+        try:
+            with open_url(request, timeout=timeout_s) as response:
+                raw = response.read().decode("utf-8", errors="replace")
+                status = getattr(response, "status", None) or response.getcode()
+        except urllib.error.HTTPError as exc:
+            err_body = exc.read().decode("utf-8", errors="replace")
+            raise RuntimeError(
+                f"HackerOne GraphQL HTTP {exc.code}: {err_body[:500]}"
+            ) from exc
+        except urllib.error.URLError as exc:
+            raise RuntimeError(f"HackerOne GraphQL network error: {exc}") from exc
+
+        if status and int(status) >= 400:
+            raise RuntimeError(f"HackerOne GraphQL HTTP {status}: {raw[:500]}")
+
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise RuntimeError("HackerOne GraphQL returned non-JSON") from exc
+
+        if data.get("errors"):
+            messages = [
+                str(item.get("message") or item)
+                for item in data["errors"]
+                if isinstance(item, dict) or item
+            ]
+            raise RuntimeError(
+                "HackerOne GraphQL errors: " + "; ".join(messages[:5])
+            )
+
+        team = (data.get("data") or {}).get("team")
+        if not team:
+            raise RuntimeError(
+                f"HackerOne program not found or not publicly visible: {handle!r}"
+            )
+
+        program_name = str(team.get("name") or program_name or handle)
+        program_id = str(team.get("id") or program_id or "")
+        scopes = team.get("structured_scopes") or {}
+        total_count = int(scopes.get("total_count") or total_count or 0)
+        batch = scopes.get("nodes") or []
+        if not isinstance(batch, list):
+            raise RuntimeError("unexpected structured_scopes.nodes shape")
+        nodes.extend(item for item in batch if isinstance(item, dict))
+
+        page_info = scopes.get("pageInfo") or {}
+        if not page_info.get("hasNextPage"):
+            break
+        after = page_info.get("endCursor")
+        if not after:
+            break
+
+    return _bundle_from_nodes(
+        handle=handle,
+        program_name=program_name,
+        program_id=program_id,
+        total_count=total_count or len(nodes),
+        nodes=nodes,
+    )
+
+
+def format_scope_report(bundle: ScopeBundle) -> str:
+    """Render a skill-friendly markdown report for tool results."""
+    first = bundle.first_direct_asset()
+    lines = [
+        f"# HackerOne scope: {bundle.program_name or bundle.handle}",
+        "",
+        f"- handle: `{bundle.handle}`",
+        f"- source: {bundle.source}",
+        f"- totals: {len(bundle.in_scope)} in-scope, {len(bundle.out_of_scope)} out-of-scope"
+        f" (API total_count={bundle.total_count})",
+    ]
+    if first:
+        lines.append(
+            f"- first direct URL/WILDCARD asset: `{first.identifier}` "
+            f"({first.asset_type})"
+        )
+    else:
+        lines.append(
+            "- first direct URL/WILDCARD asset: none "
+            "(confirm mobile/source/other types with the user)"
+        )
+    lines.extend(["", "## In scope"])
+    if not bundle.in_scope:
+        lines.append("(none)")
+    else:
+        for asset in bundle.in_scope:
+            bounty = "bounty" if asset.eligible_for_bounty else "no-bounty"
+            lines.append(
+                f"- {asset.identifier} | {asset.asset_type} | submission |"
+                f" {bounty}"
+                + (f" | max={asset.max_severity}" if asset.max_severity else "")
+            )
+            if asset.instruction:
+                instr = asset.instruction.strip().replace("\n", " ")
+                if len(instr) > 240:
+                    instr = instr[:237] + "..."
+                lines.append(f"  instruction: {instr}")
+
+    lines.extend(["", "## Out of scope (never test)"])
+    if not bundle.out_of_scope:
+        lines.append("(none listed)")
+    else:
+        for asset in bundle.out_of_scope:
+            lines.append(f"- {asset.identifier} | {asset.asset_type}")
+
+    if first:
+        lines.extend(
+            [
+                "",
+                "## Next step",
+                (
+                    f"Scope defined: {len(bundle.in_scope)} in-scope, "
+                    f"{len(bundle.out_of_scope)} out-of-scope. "
+                    f"Starting recon on {first.identifier}."
+                ),
+                "Load `pentest-flow` methodology only as needed; do not recon "
+                "hackerone.com itself.",
+            ]
+        )
+    return "\n".join(lines)
+
+
+def execute_hackerone_scope(args: dict[str, Any]) -> str:
+    """Builtin tool entrypoint."""
+    seed = str(args.get("program") or args.get("url") or args.get("handle") or "").strip()
+    if not seed:
+        return (
+            "[!] hackerone_scope requires program= "
+            "(handle, program URL, or .../policy_scopes link)"
+        )
+    try:
+        page_size = int(args.get("page_size") or DEFAULT_PAGE_SIZE)
+    except (TypeError, ValueError):
+        page_size = DEFAULT_PAGE_SIZE
+    try:
+        bundle = fetch_program_scope(seed, page_size=page_size)
+    except ValueError as exc:
+        return f"[!] invalid HackerOne program seed: {exc}"
+    except RuntimeError as exc:
+        return (
+            f"[!] failed to load HackerOne scope: {exc}\n"
+            "[suggestion] Ask the user to paste the Scope tab tables "
+            "(in-scope / out-of-scope) and stop before recon."
+        )
+    except Exception as exc:  # noqa: BLE001 — surface unexpected transport errors
+        return f"[!] hackerone_scope error: {exc}"
+
+    # Compact machine-readable appendix for the agent; humans read the report.
+    payload = {
+        "handle": bundle.handle,
+        "program_name": bundle.program_name,
+        "in_scope": [asdict(a) for a in bundle.in_scope],
+        "out_of_scope": [asdict(a) for a in bundle.out_of_scope],
+        "first_direct_asset": (
+            asdict(bundle.first_direct_asset())
+            if bundle.first_direct_asset()
+            else None
+        ),
+    }
+    return (
+        f"[tool:hackerone_scope]\n{format_scope_report(bundle)}\n\n"
+        f"```json\n{json.dumps(payload, ensure_ascii=False, indent=2)}\n```"
+    )
+
+
+def _bundle_from_nodes(
+    *,
+    handle: str,
+    program_name: str,
+    program_id: str,
+    total_count: int,
+    nodes: list[dict[str, Any]],
+) -> ScopeBundle:
+    in_scope: list[ScopeAsset] = []
+    out_of_scope: list[ScopeAsset] = []
+    seen: set[tuple[str, str, bool]] = set()
+
+    for node in nodes:
+        identifier = str(
+            node.get("asset_identifier")
+            or node.get("identifier")
+            or ""
+        ).strip()
+        if not identifier:
+            continue
+        asset_type = str(
+            node.get("asset_type") or node.get("display_name") or "OTHER"
+        ).strip()
+        submission = _as_bool(node.get("eligible_for_submission"), default=False)
+        bounty = _as_bool(node.get("eligible_for_bounty"), default=False)
+        key = (identifier, asset_type.upper(), submission)
+        if key in seen:
+            continue
+        seen.add(key)
+        asset = ScopeAsset(
+            identifier=identifier,
+            asset_type=asset_type.upper(),
+            eligible_for_submission=submission,
+            eligible_for_bounty=bounty,
+            max_severity=str(node.get("max_severity") or node.get("cvss_score") or ""),
+            instruction=str(node.get("instruction") or "").strip(),
+        )
+        if submission:
+            in_scope.append(asset)
+        else:
+            out_of_scope.append(asset)
+
+    return ScopeBundle(
+        handle=handle,
+        program_name=program_name,
+        program_id=program_id,
+        in_scope=in_scope,
+        out_of_scope=out_of_scope,
+        total_count=total_count,
+    )
+
+
+def _as_bool(value: Any, *, default: bool) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return default
+    if isinstance(value, (int, float)):
+        return bool(value)
+    text = str(value).strip().lower()
+    if text in {"true", "1", "yes"}:
+        return True
+    if text in {"false", "0", "no"}:
+        return False
+    return default

--- a/vulnclaw/agent/skill_context.py
+++ b/vulnclaw/agent/skill_context.py
@@ -1,10 +1,10 @@
-"""Skill reference selection helpers for AgentCore.
+"""Skill selection helpers for AgentCore.
 
-Skills are reference material, not execution scripts.  This module keeps the
-deterministic resolver and provenance trail, but prompt rendering deliberately
-exposes only a compact reference index: selected skill names, descriptions,
-resolver reason, and on-demand reference names.  The actual skill/reference body
-is loaded only when the model chooses ``load_skill_reference``.
+Keyword-selected skills remain optional reference indexes (body not injected);
+``load_skill_reference`` is still model-chosen for supporting docs.
+
+Explicit launches (``/skill`` or ``Use VulnClaw skill X``) inject the primary
+skill body so workflow skills such as ``hackerone`` actually execute.
 
 Resolving once per turn is deliberate: the recorded provenance attached to
 findings names the same reference bundle that was offered to the model.
@@ -139,10 +139,11 @@ def resolve_active_skill_selection(
 
 
 def apply_skill_selection(state: Any, user_input: Optional[str] = None) -> Optional[str]:
-    """Resolve, record provenance on ``state``, and return a reference index.
+    """Resolve, record provenance on ``state``, and return skill prompt context.
 
-    Skill bodies are never injected automatically.  A selected bundle only tells
-    the model which reference files may be useful if it decides to load them.
+    Keyword-selected skills stay optional indexes (body not injected). Explicit
+    slash / "Use VulnClaw skill" launches inject the primary skill body so
+    workflow skills such as ``hackerone`` are actually executable.
     """
 
     phase_label = getattr(getattr(state, "phase", None), "value", None)
@@ -163,7 +164,7 @@ def apply_skill_selection(state: Any, user_input: Optional[str] = None) -> Optio
 
 
 def get_active_skill_context(user_input: Optional[str] = None, **kwargs: Any) -> Optional[str]:
-    """Get the most relevant optional reference index without recording provenance."""
+    """Get skill prompt context without recording provenance."""
 
     if user_input or kwargs.get("task_summary"):
         selection = resolve_active_skill_selection(user_input, **kwargs)
@@ -172,21 +173,96 @@ def get_active_skill_context(user_input: Optional[str] = None, **kwargs: Any) ->
     return None
 
 
-def format_selection_context(selection: SkillSelection) -> str:
-    """Render a resolved bundle as optional reference material.
+def _is_explicit_selection(selection: SkillSelection) -> bool:
+    """True when the user explicitly launched this skill (slash or Use-skill)."""
+    if "explicit" in (selection.signals or []):
+        return True
+    reason = (selection.reason or "").lower()
+    return reason.startswith("explicit")
 
-    The primary skill instructions are intentionally not injected here.  This
-    keeps the model in control of strategy and makes ``load_skill_reference`` an
-    explicit, model-chosen read action.
+
+# Soft cap so a huge SKILL.md cannot monopolize the system prompt.
+_EXPLICIT_SKILL_BODY_MAX_CHARS = 48_000
+
+
+def format_selection_context(selection: SkillSelection) -> str:
+    """Render a resolved skill bundle for the system prompt.
+
+    Explicit launches inject the primary skill body as the active workflow.
+    Keyword / fallback selection still injects only an optional reference index
+    so the model remains free to ignore suggested methodology.
     """
 
+    primary = load_skill_by_name(selection.primary) if selection.primary else None
+    if _is_explicit_selection(selection) and primary:
+        return _format_explicit_skill_context(selection, primary)
+    return _format_optional_skill_index(selection, primary)
+
+
+def _format_explicit_skill_context(
+    selection: SkillSelection, primary: dict[str, Any]
+) -> str:
+    body = str(primary.get("content") or "").strip()
+    if len(body) > _EXPLICIT_SKILL_BODY_MAX_CHARS:
+        body = (
+            body[:_EXPLICIT_SKILL_BODY_MAX_CHARS]
+            + "\n\n[skill body truncated for prompt budget]"
+        )
+
+    parts: list[str] = [
+        f"## Active skill (explicit invocation) — `{selection.primary}`",
+        (
+            "The operator launched this skill deliberately via a slash command or "
+            '"Use VulnClaw skill ...". Follow its workflow as the primary plan unless '
+            "the user overrides it. Do not reverse-engineer scope hosts (for example "
+            "do not run js_recon against hackerone.com)."
+        ),
+    ]
+    if body:
+        parts.append(body)
+    else:
+        desc = primary.get("description", "").strip()
+        parts.append(desc or f"(skill {selection.primary} has an empty body)")
+
+    support_lines: list[str] = []
+    for name in selection.supporting:
+        skill = load_skill_by_name(name)
+        if not skill:
+            continue
+        desc = skill.get("description", "").strip()
+        summary = desc.splitlines()[0] if desc else "(no description)"
+        support_lines.append(f"- optional supporting reference: {name} — {summary}")
+    if support_lines:
+        parts.append(
+            "Optional supporting skills (not mandatory):\n" + "\n".join(support_lines)
+        )
+
+    refs = primary.get("references", []) or []
+    if refs:
+        ref_list = ", ".join(refs[:10])
+        if len(refs) > 10:
+            ref_list += f", ... ({len(refs)} total)"
+        parts.append(
+            "Optional reference files for this skill — load only when needed with "
+            f"`load_skill_reference`: {ref_list}"
+        )
+
+    if selection.reason:
+        parts.append(
+            f"<!-- skill routing: {selection.reason}; confidence={selection.confidence:.2f} -->"
+        )
+    return "\n\n".join(part for part in parts if part)
+
+
+def _format_optional_skill_index(
+    selection: SkillSelection, primary: Optional[dict[str, Any]]
+) -> str:
     parts: list[str] = [
         "These skills are optional reference material only. They are not mandatory "
         "workflows, phases, checklists, or tool schedules. Use or ignore them based "
         "on the current evidence and your own reasoning."
     ]
 
-    primary = load_skill_by_name(selection.primary) if selection.primary else None
     if primary:
         desc = primary.get("description", "").strip()
         summary = desc.splitlines()[0] if desc else "(no description)"

--- a/vulnclaw/skills/specialized/hackerone/SKILL.md
+++ b/vulnclaw/skills/specialized/hackerone/SKILL.md
@@ -1,33 +1,59 @@
 ---
 name: hackerone
-description: HackerOne 赏金项目 scope-guard 流程 — 读取 program scope，强制 scope 与 program rules，再逐个把 in-scope asset 交给 pentest-flow
+description: HackerOne bounty program scope-guard workflow — reads program scope, enforces scope and program rules, then hands each in-scope asset to pentest-flow
 requires_target: false
 ---
 
-# HackerOne 赏金 scope-guard Skill
+# HackerOne Bounty Scope-Guard Skill
 
-你当前正在执行 HackerOne bug bounty 流程。本 Skill 是一层 **scope-guard wrapper**：
-先解析并强制 program scope 与 program rules，再把每个 **in-scope asset** 交给
-`pentest-flow` Skill 执行真正的渗透。**严禁在任何阶段触碰 out-of-scope asset。**
+You are executing a HackerOne bug bounty workflow. This Skill is a
+**scope-guard wrapper**: first parse and enforce the program scope and program
+rules, then hand each **in-scope asset** to `pentest-flow` for the actual
+security testing. **Never touch an out-of-scope asset at any stage.**
 
-启动参数是一个 HackerOne program 链接（`<SCOPE LINK>`），例如
-`hackerone.com/<handle>` 或 `.../policy_scopes`。本 Skill 无预设 target
-（frontmatter `requires_target: false`）——target 从 scope 中发现。
+The launch argument is a HackerOne program link (`<SCOPE LINK>`), for example
+`hackerone.com/<handle>` or `.../policy_scopes`. This Skill has no preset scan
+target (`requires_target: false` in frontmatter); targets are discovered from
+the program scope.
 
-## 阶段一：读取 scope（Read scope）
+## Startup and output contract
 
-1. **优先 fetch 链接**
-   - 用 fetch 工具访问传入的 `<SCOPE LINK>`。
-   - HackerOne 是 JavaScript SPA：`hackerone.com/*` 的 fetch 通常只返回
-     **空 app shell**，没有渲染出的 scope 行（scope 数据来自 `hackerone.com/graphql`
-     或 authenticated `api.hackerone.com`，naive fetch 拿不到）。
-   - **检测空壳**：若响应中没有可识别的 scope 表格 / asset 列表（只有
-     `<div id="app">` 之类的骨架），判定为 fetch 失败。
+- Do not load or print the reference document during startup. It contains
+  report-template material and examples; load it only when preparing a report
+  or when parsing an ambiguous scope requires it.
+- Resolve the supplied program link or obtain a pasted scope before claiming
+  that scope is defined. Never treat example assets in this Skill or its
+  references as observed program scope.
+- Once scope is confirmed, keep the status concise:
+  `Scope defined: <count> in-scope, <count> out-of-scope. Starting recon on <asset>.`
+- Automatically begin recon on the first confirmed `URL` or `WILDCARD` asset
+  after you have printed that status in the same workflow that loaded scope.
+  Do not pause for an asset-selection question unless scope is ambiguous,
+  contains no directly supported assets, or the user explicitly asks to choose.
+- Mid-session user **check-ins** (e.g. "ready to begin?", "are we ready?") are
+  not a green light by themselves: answer with scope summary, intended first
+  asset, and any blockers first. Start or resume recon tools only after an
+  explicit go-ahead or a clear recon/pentest command.
+- Do not print raw HTML, full reference text, or raw tool output. If scope cannot
+  be loaded, ask the user to paste the Scope tab and stop before testing.
+- **Never treat `hackerone.com` as the recon/pentest target.** The program link is
+  only a discovery seed. Do not run `js_recon`, `dir_enum`, `subdomain_enum`, or
+  attack tooling against HackerOne itself.
 
-2. **fallback：请用户粘贴 scope**
-   - fetch 为空 / 被 login-wall / 仅 JS 渲染时，**这是常态而非例外**。
-   - 请用户从 program 页面的 **Scope** 标签把 in-scope 与 out-of-scope 两张表
-     直接粘贴过来。给出一个可参照的粘贴格式示例：
+## Phase 1: Read scope
+
+1. **Call `hackerone_scope` first (required)**
+   - Immediately call: `hackerone_scope(program="<SCOPE LINK or handle>")`.
+   - This tool queries HackerOne public GraphQL and returns structured in-scope
+     and out-of-scope assets. Use it even if a prior HTML fetch showed an empty SPA shell.
+   - **Do not** reverse-engineer HackerOne JavaScript bundles, dump `/assets/static/*`,
+     or run `js_recon` on `hackerone.com/*` to discover the GraphQL endpoint.
+
+2. **Fallback only if `hackerone_scope` fails**
+   - Optional one-shot GET of the program page is allowed only as diagnostics;
+     an empty SPA shell is normal and not a scope source.
+   - Ask the user to paste the in-scope and out-of-scope tables from the program
+     page **Scope** tab. Provide this example format:
 
      ```
      In scope:
@@ -41,72 +67,93 @@ requires_target: false
      *.corp.example.com             | WILDCARD
      ```
 
-3. **宽松解析（lenient parse）**
-   - 从粘贴或 fetch 结果中提取两个列表：**in-scope** 与 **out-of-scope**。
-   - 识别 asset type（human label 或 API enum 均可）：
-     `URL`、`WILDCARD`（`*.x.com`）、`CIDR`/IP、`SOURCE_CODE`、
-     `GOOGLE_PLAY_APP_ID`/`APPLE_STORE_APP_ID`/`TESTFLIGHT`/`OTHER_APK`/`OTHER_IPA`、
-     `HARDWARE`、`AI_MODEL`、`SMART_CONTRACT`、`OTHER` 等。
-   - 识别 **eligibility 三态**（submission 与 bounty 是两个独立布尔）：
-     - `submission=true, bounty=true` → in scope，可测，有赏金。
-     - `submission=true, bounty=false` → **in scope，可测，无赏金**（勿与 out-of-scope 混淆）。
-     - `submission=false` → **out of scope，绝不测试**。
-   - 解析不确定时，向用户确认，**绝不把 asset 默认当作 in-scope**。
+3. **Parse leniently**
+   - Extract two lists from the tool result or paste: **in-scope** and
+     **out-of-scope**.
+   - Recognize asset types by human label or API enum:
+     `URL`, `WILDCARD` (`*.x.com`), `CIDR`/IP, `SOURCE_CODE`,
+     `GOOGLE_PLAY_APP_ID`/`APPLE_STORE_APP_ID`/`TESTFLIGHT`/`OTHER_APK`/`OTHER_IPA`,
+     `HARDWARE`, `AI_MODEL`, `SMART_CONTRACT`, `OTHER`, and similar values.
+   - Recognize **three eligibility states**. Submission eligibility and bounty
+     eligibility are independent booleans:
+     - `submission=true, bounty=true` → in scope, testable, bounty eligible.
+     - `submission=true, bounty=false` → **in scope, testable, not bounty eligible**.
+       Do not confuse this with out of scope.
+     - `submission=false` → **out of scope; never test it**.
+   - If parsing is uncertain, ask the user to confirm. **Never default an
+     uncertain asset to in-scope.**
 
-4. **输出**
-   - in-scope asset 列表（含 type + eligibility）。
-   - out-of-scope **deny-list**（用于全程强制）。
+4. **Record the boundary internally**
+   - Keep the in-scope assets with their type and eligibility available to the
+     workflow.
+   - Keep an out-of-scope **deny-list** for enforcement throughout the run.
 
-## 阶段二：强制边界（Enforce boundaries）
+## Phase 2: Enforce boundaries
 
-在进入任何测试前，明确写下并全程遵守以下 **硬性规则**：
+Before any testing begins, state and follow these **hard rules** throughout:
 
-1. **Scope 硬边界**
-   - 只测试 in-scope 列表中的 asset。
-   - out-of-scope deny-list 中的 asset **绝不触碰**——不 fetch、不扫描、不发任何 payload。
-   - `pentest-flow` 只能直接作用于 `URL` 与 `WILDCARD` 类型；其它类型
-     （mobile app / source / CIDR / hardware 等）暂不自动化，需先与用户确认处理方式。
+1. **Scope boundary**
+   - Test only assets in the in-scope list.
+   - Never touch an asset on the out-of-scope deny-list: do not fetch it, scan
+     it, or send any payload to it.
+   - `pentest-flow` may directly handle only `URL` and `WILDCARD` assets. Other
+     types (mobile apps, source code, CIDR, hardware, and so on) are not
+     automated; ask the user to confirm how they should be handled.
 
-2. **Program rules（层叠在 VulnClaw 既有 `BLOCKED_PATTERNS` / `RESERVED_IP_RANGES` 之上）**
-   - **no DoS / 无可用性影响**：禁止压力测试、资源耗尽、批量并发（自动化扫描器的首要红线）。
-   - **尊重 rate limit / automation limit**：低速、串行；遵守 program 声明的 "no automated scanning" 条款。
-   - **no social engineering**：不针对人员，不钓鱼。
-   - **minimal impact / no PII exfil**：验证漏洞即止，不导出真实用户数据、不做破坏性操作。
+2. **Program rules** (in addition to VulnClaw's existing `BLOCKED_PATTERNS` and
+   `RESERVED_IP_RANGES`)
+   - **No DoS or availability impact**: prohibit stress tests, resource
+     exhaustion, and high-volume concurrency.
+   - **Respect rate and automation limits**: operate slowly and serially, and
+     follow any program rule that prohibits automated scanning.
+   - **No social engineering**: do not target or phish people.
+   - **Minimal impact and no PII exfiltration**: stop once a vulnerability is
+     verified; do not export real user data or perform destructive actions.
 
-3. **异常处理**
-   - 任何一步若可能越过 scope 或触发上述规则，**停止并询问用户**。
+3. **Handle exceptions safely**
+   - If any step could cross the scope boundary or violate a program rule,
+     stop and ask the user.
 
-## 阶段三：枚举与确认（Enumerate & confirm）
+## Phase 3: Enumerate and confirm
 
-1. 向用户列出全部已解析的 in-scope asset（编号、type、eligibility）。
-2. 询问从哪个 asset 开始（或全部）。
-3. **一次只处理一个 asset**，逐个确认，避免并发导致越界或触发 rate limit。
+1. Use the concise startup status from the output contract and select the
+   first directly supported asset automatically.
+2. Ask which asset to start with only when the output contract requires it.
+3. **Handle one asset at a time** and confirm each one separately. Avoid
+   concurrency that could cross the scope boundary or trigger rate limits.
 
-## 阶段四：委派 pentest-flow（Delegate）
+## Phase 4: Delegate to pentest-flow
 
-对用户选定的 **单个 in-scope asset**：
+For the selected **single in-scope asset**:
 
-1. 将该 asset 作为 target 交给 `pentest-flow` Skill，执行
-   recon → vuln-discovery → exploitation 全流程。
-2. 全程保持在 scope 内：`pentest-flow` 发现的新子域 / 端点若超出
-   in-scope 定义（尤其不匹配任何 in-scope `WILDCARD`），**排除**并提示用户。
-3. 持续对照阶段二的 program rules。
+1. Treat that asset as the active target. Run the full
+   recon → vulnerability-discovery → exploitation workflow against **it**, not
+   against the HackerOne scope link.
+2. Stay within scope throughout. Exclude and report any newly discovered
+   subdomain or endpoint that is outside the in-scope definition, especially
+   one that does not match an in-scope `WILDCARD`.
+3. Continue to enforce all Phase 2 program rules.
 
-## 阶段五：报告（Report — HackerOne submission format）
+## Phase 5: Report in HackerOne format
 
-对每个确认的 finding，按 **HackerOne 提交格式** 输出一份报告：
+For every confirmed finding, produce a report in **HackerOne submission format**:
 
-1. **Title** — 简洁描述漏洞（type + 受影响 asset）。
-2. **Asset** — 受影响的 in-scope asset（URL / 标识）。
-3. **Severity (CVSS)** — CVSS 向量与分数（Critical/High/Medium/Low）。
-4. **Steps to Reproduce** — 可复现的分步操作（含请求 / 响应 / payload）。
-5. **Impact** — 可利用性与业务影响。
-6. **Remediation** — 修复建议。
+1. **Title** — concise description of the vulnerability, including its type and
+   affected asset.
+2. **Asset** — the affected in-scope asset (URL or identifier).
+3. **Severity (CVSS)** — CVSS vector and score (Critical/High/Medium/Low).
+4. **Steps to Reproduce** — reproducible steps, including requests, responses,
+   and payloads.
+5. **Impact** — exploitability and business impact.
+6. **Remediation** — recommended fix.
 
-多个 finding 时，每个独立成节；附可参数化的 Python PoC（requests 库）。
-提醒用户：报告仅供其在 HackerOne 上 **人工提交**，本 Skill 不自动上报。
+When there are multiple findings, keep each one in a separate section. Include
+a parameterized Python PoC using `requests` when useful.
+Remind the user that reports are for **manual submission** on HackerOne; this
+Skill never submits reports automatically.
 
-## 参考文档
+## References
 
-- `references/hackerone-report-and-scope.md` — scope 解析参考（asset type ↔ API enum、
-  eligibility 三态、粘贴表形状）、program rules 强制清单、HackerOne 提交格式报告模板。
+- `references/hackerone-report-and-scope.md` — scope parsing reference (asset
+  type ↔ API enum, three-state eligibility, pasted table shapes), mandatory
+  program rules, and the HackerOne report template.

--- a/vulnclaw/skills/specialized/hackerone/references/hackerone-report-and-scope.md
+++ b/vulnclaw/skills/specialized/hackerone/references/hackerone-report-and-scope.md
@@ -1,34 +1,35 @@
-# HackerOne 报告模板与 scope 解析参考
+# HackerOne Report Template and Scope Parsing Reference
 
-本参考供 `hackerone` Skill 使用：右侧是 **scope 解析** 的目标形状，左侧是
-**HackerOne 提交格式** 的报告模板。技术术语保留英文原文。
+This reference supports the `hackerone` Skill. It defines the target shape for
+scope parsing and the report format for HackerOne submissions. Technical terms
+and API identifiers remain in their original English form.
 
-## 1. Scope 解析参考
+## 1. Scope parsing reference
 
-### 1.1 asset type（human label ↔ API enum）
+### 1.1 Asset type (human label ↔ API enum)
 
-| Human label            | API enum                                   | pentest-flow 可直接处理 |
-| ---------------------- | ------------------------------------------ | ----------------------- |
-| Domain / URL           | `URL`                                      | ✅                      |
-| Wildcard `*.x.com`     | `WILDCARD`                                 | ✅                      |
-| IP range / CIDR        | `CIDR`                                     | ⚠️ 需确认（可能受限）   |
-| Source code            | `SOURCE_CODE`                              | ❌ 人工                 |
-| Android app            | `GOOGLE_PLAY_APP_ID` / `OTHER_APK`         | ❌ 需专用流程           |
-| iOS app                | `APPLE_STORE_APP_ID` / `TESTFLIGHT` / `OTHER_IPA` | ❌ 需专用流程    |
-| Hardware               | `HARDWARE`                                 | ❌ 人工                 |
-| AI Model               | `AI_MODEL`                                 | ❌ 人工                 |
-| Smart Contract         | `SMART_CONTRACT`                           | ❌ 人工                 |
-| Other / ASN            | `OTHER`                                    | ⚠️ 需确认               |
+| Human label | API enum | Directly supported by pentest-flow |
+| --- | --- | --- |
+| Domain / URL | `URL` | ✅ |
+| Wildcard `*.x.com` | `WILDCARD` | ✅ |
+| IP range / CIDR | `CIDR` | ⚠️ Confirm first; may be restricted |
+| Source code | `SOURCE_CODE` | ❌ Manual handling |
+| Android app | `GOOGLE_PLAY_APP_ID` / `OTHER_APK` | ❌ Requires a dedicated workflow |
+| iOS app | `APPLE_STORE_APP_ID` / `TESTFLIGHT` / `OTHER_IPA` | ❌ Requires a dedicated workflow |
+| Hardware | `HARDWARE` | ❌ Manual handling |
+| AI model | `AI_MODEL` | ❌ Manual handling |
+| Smart contract | `SMART_CONTRACT` | ❌ Manual handling |
+| Other / ASN | `OTHER` | ⚠️ Confirm first |
 
-### 1.2 eligibility 三态（submission × bounty 两个独立布尔）
+### 1.2 Three-state eligibility (submission × bounty)
 
-| submission | bounty | 含义                                    | 行为             |
-| ---------- | ------ | --------------------------------------- | ---------------- |
-| true       | true   | in scope，可测，有赏金                  | 正常测试         |
-| true       | false  | in scope，可测，**无赏金**              | 正常测试（勿跳过）|
-| false      | —      | **out of scope**                        | **绝不触碰**     |
+| Submission | Bounty | Meaning | Action |
+| --- | --- | --- | --- |
+| true | true | In scope and bounty eligible | Test normally |
+| true | false | **In scope but not bounty eligible** | Test normally; do not skip |
+| false | — | **Out of scope** | **Never touch it** |
 
-### 1.3 粘贴 scope 表的目标形状（lenient parse）
+### 1.3 Pasted scope table shape (lenient parsing)
 
 ```
 In scope:
@@ -42,45 +43,54 @@ blog.example.com               | URL
 *.corp.example.com             | WILDCARD
 ```
 
-解析要点：
-- 每行至少提取 **asset 标识** 与 **in/out 归属**；type 与 eligibility 尽量识别。
-- 列顺序、分隔符（`|`、tab、多空格）都可能变化——按 token 宽松匹配。
-- 任何无法确定归属的行，**向用户确认，绝不默认 in-scope**。
+Parsing rules:
 
-## 2. Program rules 强制清单
+- Extract at least the **asset identifier** and its in/out classification from
+  every row. Identify the type and eligibility whenever possible.
+- Column order and separators may vary (`|`, tabs, or multiple spaces); use
+  lenient token matching.
+- If a row's classification is uncertain, ask the user to confirm. **Never
+  default an uncertain row to in-scope.**
 
-在测试任一 asset 前逐条对照：
+## 2. Mandatory program rules
 
-- **no DoS / 无可用性影响** —— 禁止压力测试、资源耗尽、批量并发。
-- **rate limit / automation limit** —— 低速串行；遵守 "no automated scanning" 条款。
-- **no social engineering** —— 不针对人员、不钓鱼。
-- **minimal impact / no PII exfil** —— 验证即止，不导出真实用户数据。
-- 叠加于 VulnClaw 既有 `BLOCKED_PATTERNS` / `RESERVED_IP_RANGES` 之上。
+Check these rules before testing any asset:
 
-## 3. HackerOne 提交格式报告模板
+- **No DoS or availability impact** — prohibit stress tests, resource
+  exhaustion, and high-volume concurrency.
+- **Rate and automation limits** — operate slowly and serially; follow any rule
+  that prohibits automated scanning.
+- **No social engineering** — do not target or phish people.
+- **Minimal impact and no PII exfiltration** — stop after verification and do
+  not export real user data.
+- These rules supplement VulnClaw's existing `BLOCKED_PATTERNS` and
+  `RESERVED_IP_RANGES` protections.
 
-每个 finding 用如下结构：
+## 3. HackerOne submission report template
+
+Use this structure for each finding:
 
 ```markdown
-### [Title] <漏洞类型> on <asset>
+### [Title] <vulnerability type> on <asset>
 
-**Asset:** <受影响的 in-scope asset（URL / 标识）>
+**Asset:** <affected in-scope asset (URL or identifier)>
 
 **Severity (CVSS):** <Critical | High | Medium | Low> —
 `CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N` (score: X.X)
 
 **Steps to Reproduce:**
-1. <步骤，含请求 / 响应 / payload>
+1. <step, including request, response, or payload>
 2. ...
 
 **Impact:**
-<可利用性与业务影响>
+<exploitability and business impact>
 
 **Remediation:**
-<修复建议>
+<recommended fix>
 
 **Proof of Concept:**
-（附可参数化的 Python PoC，requests 库；仅用于验证，无破坏性）
+<parameterized Python PoC using requests; verification only, with no destructive action>
 ```
 
-提醒：报告仅供用户在 HackerOne 上 **人工提交**，Skill 不自动上报。
+Reports are for the user to **submit manually** on HackerOne. The Skill never
+submits reports automatically.


### PR DESCRIPTION
Fixes #226.

## Summary

Gives the `hackerone` skill a deterministic scope source and makes its scope-guard workflow actually reach the model on an explicit launch. Three coordinated changes:

1. **`vulnclaw/agent/hackerone_scope.py` (new, 378 lines).** Queries the public HackerOne GraphQL endpoint (`https://hackerone.com/graphql`, `VulnClawStructuredScopes`) and normalizes `structured_scopes` nodes into `ScopeAsset`/`ScopeBundle` with the two independent booleans HackerOne actually models — `eligible_for_submission` and `eligible_for_bounty`. `execute_hackerone_scope(args)` is the entry point; `format_scope_report` renders the in-scope / out-of-scope split. Handle extraction (`extract_program_handle`) accepts `hackerone.com/<handle>`, `.../policy_scopes`, or a bare handle, validated against `_HANDLE_RE`.

2. **`vulnclaw/agent/skill_context.py` (+106).** `format_selection_context` now branches: an *explicit* launch (`/skill` or "Use VulnClaw skill X", detected via `_is_explicit_selection`) injects the primary skill body as the active workflow through `_format_explicit_skill_context`, capped at 48k chars; keyword/fallback selection keeps rendering the optional reference index via `_format_optional_skill_index`. The withheld-body behavior for keyword routing is unchanged — see below.

3. **Skill docs.** `SKILL.md` and `references/hackerone-report-and-scope.md` rewritten from Chinese into English (matching the `#193` English-default contract) and Phase 1 repointed at `hackerone_scope` as the required first step, with the paste-the-Scope-tab flow demoted to an explicit fallback.

## Why keyword-selected skills still don't inject their body

The "never inject the skill body" rule was a *deliberate* boundary for keyword/fallback routing: it keeps the model in control of strategy and makes reference reads an explicit, model-chosen action. This PR does not weaken that. Bodies open only for explicit operator launches, where the operator has already chosen the workflow. `_format_optional_skill_index` is the unchanged path for everything else.

## Out of scope — read this before reviewing the skill

`SKILL.md` Phase 1 instructs the model to `Call hackerone_scope first (required)`, but **this PR does not register `hackerone_scope` as a callable builtin tool.** The runtime wiring — dispatch in `builtin_tools.py`, the schema in `tool_schemas.py`, and the `constraint_policy.py` / `roles.py` allowlists — is a separate change and lands in a companion PR. The obvious wrong read is that the skill references a tool that does not exist anywhere; it exists as a tested module here, and the registration is the follow-up. The two are split so this PR stays a self-contained, independently reviewable unit: the scope-loading logic and the guarded workflow, without the tool-surface changes that touch the shared constraint and role tables.

Concretely, on this branch `execute_hackerone_scope` is exercised directly by its unit tests but is not yet reachable through the agent's tool loop. `tests/agent/test_regression_prior_fixes.py`, which asserts `hackerone_scope` is present in the builtin schema set, is intentionally left with the companion PR for the same reason.

## Verification

```
$ ruff check vulnclaw tests
All checks passed!

$ python -m pytest -q tests/agent/test_hackerone_scope.py tests/skills/test_skills.py \
    tests/agent/test_agent.py::TestAgentCore::test_skill_context_explicit_slash_skill_selector
79 passed, 1 warning in 2.68s
```

The two failures are `tests/run/test_run_persistence.py::test_multi_target_run_seeds_secondary_state_and_resumes` and `::test_orchestrator_checkpoints_and_resumes_exact_run`. Correction: they are an artifact of my checkout location, not a defect in `dev`. That file writes snapshot paths roughly 190 characters below the repo root, so from a deeply nested working copy the writes exceed Windows `MAX_PATH` and fail with `FileNotFoundError` on the `.tmp` file. The same commit passes the full suite with zero failures from a short path (`C:cshort`). Nothing in this PR touches run persistence.

## Files

- `vulnclaw/agent/hackerone_scope.py` — new module
- `vulnclaw/agent/skill_context.py` — explicit-launch body injection
- `vulnclaw/skills/specialized/hackerone/SKILL.md`, `.../references/hackerone-report-and-scope.md` — English rewrite, repointed Phase 1
- `tests/agent/test_hackerone_scope.py` — new unit coverage
- `tests/skills/test_skills.py` — asserts the skill/reference are English and name the loader
- `tests/agent/test_agent.py` — one assertion updated to the explicit-injection contract (the only hackerone-adjacent hunk; the unrelated `input_analysis` test change from the source branch is deliberately excluded)


