### PR TITLE
feat(config): add OpenRouter provider preset and scope the saved API key to its provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,11 +12,12 @@
 # Required: API key for your provider.
 VULNCLAW_LLM_API_KEY=sk-your-key-here
 
-# Provider label (openai, anthropic, deepseek, zhipu, minimax, moonshot, qwen, ...).
+# Provider label (openai, openrouter, anthropic, deepseek, zhipu, minimax, ...).
 VULNCLAW_LLM_PROVIDER=openai
 
 # API base URL — MUST match your key's provider. Examples:
 #   OpenAI     https://api.openai.com/v1
+#   OpenRouter https://openrouter.ai/api/v1
 #   Anthropic  https://api.anthropic.com/v1
 #   DeepSeek   https://api.deepseek.com
 #   Zhipu      https://open.bigmodel.cn/api/paas/v4
@@ -24,8 +25,9 @@ VULNCLAW_LLM_PROVIDER=openai
 #   Qwen       https://dashscope.aliyuncs.com/compatible-mode/v1
 VULNCLAW_LLM_BASE_URL=https://api.openai.com/v1
 
-# Model name — MUST match the provider above (e.g. gpt-4o, deepseek-chat,
-# claude-sonnet-5, glm-4.7, kimi-k2.6, qwen3-max).
+# Model name — MUST match the provider above (e.g. gpt-4o,
+# claude-sonnet-5 for Anthropic, anthropic/claude-sonnet-5 for OpenRouter,
+# deepseek-chat, glm-4.7, kimi-k2.6, qwen3-max).
 VULNCLAW_LLM_MODEL=gpt-4o
 
 # Optional: token / sampling tuning.

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -275,9 +275,22 @@ class TestVulnClawConfig:
             "moonshot",
             "qwen",
             "siliconflow",
+            "openrouter",
         ]
         for provider in expected_providers:
             assert provider in PROVIDER_PRESETS, f"Missing provider: {provider}"
+
+    def test_openrouter_preset_uses_namespaced_default_model(self):
+        """OpenRouter is an aggregator: one OpenAI-compatible endpoint fronting
+        many vendors, so model IDs carry a ``vendor/model`` prefix. No provider
+        specific code path is needed beyond the preset."""
+        from vulnclaw.config.schema import PROVIDER_PRESETS, LLMProvider
+
+        assert LLMProvider("openrouter") is LLMProvider.OPENROUTER
+        preset = PROVIDER_PRESETS[LLMProvider.OPENROUTER]
+        assert preset["base_url"] == "https://openrouter.ai/api/v1"
+        assert preset["default_model"] == "anthropic/claude-sonnet-5"
+        assert preset["label"] == "OpenRouter"
 
     def test_ollama_preset_points_at_local_openai_endpoint(self):
         """Ollama is a first-class preset so it appears in `vulnclaw config`

--- a/tests/web/test_web.py
+++ b/tests/web/test_web.py
@@ -154,31 +154,85 @@ class TestWebServices:
         assert resp.models == []
         assert "key" in resp.detail.lower()
 
-    def test_web_provider_service_fetch_models_honors_request_base_url(self, monkeypatch):
+    def test_web_provider_service_fetch_models_rejects_cross_provider_saved_key(self, monkeypatch):
         import vulnclaw.web.services.provider_service as provider_service
         from vulnclaw.config.schema import VulnClawConfig
         from vulnclaw.web.schemas import ProviderModelsRequest
 
         config = VulnClawConfig()
-        config.llm.api_key = "sk-test"
-        config.llm.base_url = "https://config-default.example/v1"
+        config.llm.provider = "deepseek"
+        config.llm.api_key = "sk-deepseek"
+        config.llm.base_url = "https://api.deepseek.com/v1"
+        monkeypatch.setattr(provider_service, "load_config", lambda: config)
+
+        def must_not_call(*args, **kwargs):
+            raise AssertionError("a saved key must not cross provider boundaries")
+
+        monkeypatch.setattr(provider_service, "fetch_provider_models", must_not_call)
+
+        resp = provider_service.fetch_models(
+            ProviderModelsRequest(provider="openai", base_url="https://api.openai.com/v1")
+        )
+        assert resp.base_url == "https://api.openai.com/v1"
+        assert resp.models == []
+        assert resp.has_api_key is True
+        assert "saved provider" in resp.detail.lower()
+
+    def test_web_provider_service_fetch_models_rejects_saved_key_for_different_base_url(
+        self, monkeypatch
+    ):
+        import vulnclaw.web.services.provider_service as provider_service
+        from vulnclaw.config.schema import VulnClawConfig
+        from vulnclaw.web.schemas import ProviderModelsRequest
+
+        config = VulnClawConfig()
+        config.llm.provider = "openai"
+        config.llm.api_key = "sk-openai"
+        config.llm.base_url = "https://api.openai.com/v1"
+        monkeypatch.setattr(provider_service, "load_config", lambda: config)
+
+        def must_not_call(*args, **kwargs):
+            raise AssertionError("a saved key must not cross base URL boundaries")
+
+        monkeypatch.setattr(provider_service, "fetch_provider_models", must_not_call)
+
+        resp = provider_service.fetch_models(
+            ProviderModelsRequest(provider="openai", base_url="https://openrouter.ai/api/v1")
+        )
+        assert resp.models == []
+        assert resp.has_api_key is True
+        assert "base url" in resp.detail.lower()
+
+    @pytest.mark.parametrize("saved_provider", ["custom", "openai"])
+    def test_web_provider_service_fetch_models_uses_saved_key_for_matching_custom_base_url(
+        self, monkeypatch, saved_provider
+    ):
+        import vulnclaw.web.services.provider_service as provider_service
+        from vulnclaw.config.schema import VulnClawConfig
+        from vulnclaw.web.schemas import ProviderModelsRequest
+
+        config = VulnClawConfig()
+        config.llm.provider = saved_provider
+        config.llm.api_key = "sk-custom"
+        config.llm.base_url = "https://llm.example.com/v1/"
         monkeypatch.setattr(provider_service, "load_config", lambda: config)
 
         captured = {}
 
         def fake_fetch(base_url, api_key, timeout=10.0):
-            captured["base_url"] = base_url
-            return ["m"]
+            captured.update(base_url=base_url, api_key=api_key)
+            return ["custom-model"]
 
         monkeypatch.setattr(provider_service, "fetch_provider_models", fake_fetch)
 
-        # A known provider preset base_url is trusted and gets the saved key.
         resp = provider_service.fetch_models(
-            ProviderModelsRequest(base_url="https://api.openai.com/v1")
+            ProviderModelsRequest(provider=saved_provider, base_url="https://llm.example.com/v1")
         )
-        assert captured["base_url"] == "https://api.openai.com/v1"
-        assert resp.base_url == "https://api.openai.com/v1"
-        assert resp.models == ["m"]
+        assert resp.models == ["custom-model"]
+        assert captured == {
+            "base_url": "https://llm.example.com/v1",
+            "api_key": "sk-custom",
+        }
 
     def test_web_provider_service_fetch_models_rejects_untrusted_base_url(self, monkeypatch):
         """An arbitrary client-supplied base_url must never receive the saved API key."""

--- a/vulnclaw/config/schema.py
+++ b/vulnclaw/config/schema.py
@@ -27,6 +27,7 @@ class LLMProvider(str, Enum):
     STEPFUN = "stepfun"
     SENSETIME = "sensetime"
     YI = "yi"
+    OPENROUTER = "openrouter"
     OLLAMA = "ollama"
     CUSTOM = "custom"
 
@@ -98,6 +99,15 @@ PROVIDER_PRESETS: dict[LLMProvider, dict[str, str]] = {
         "default_model": "yi-lightning",
         "label": "零一万物 (Yi)",
     },
+    # Aggregator fronting many vendors behind one OpenAI-compatible endpoint.
+    # Model IDs are namespaced by vendor (anthropic/..., openai/..., ...), so the
+    # default carries its vendor prefix. Pick a tool-capable model — VulnClaw
+    # drives everything through function calls.
+    LLMProvider.OPENROUTER: {
+        "base_url": "https://openrouter.ai/api/v1",
+        "default_model": "anthropic/claude-sonnet-5",
+        "label": "OpenRouter",
+    },
     # Local models via Ollama's OpenAI-compatible endpoint. No API key is
     # required (the client sends a placeholder). The default model must support
     # tool calling — VulnClaw drives everything through function calls — so pick
@@ -121,7 +131,7 @@ class LLMConfig(BaseModel):
 
     provider: str = Field(
         default="openai",
-        description="LLM provider name (openai/anthropic/minimax/deepseek/zhipu/moonshot/qwen/siliconflow/doubao/baichuan/stepfun/sensetime/yi/ollama/custom)",
+        description="LLM provider name (openai/anthropic/minimax/deepseek/zhipu/moonshot/qwen/siliconflow/doubao/baichuan/stepfun/sensetime/yi/openrouter/ollama/custom)",
     )
     api_key: str = Field(default="", description="Static API key for the chosen provider (auth_mode=static)")
     api_keys: list[str] = Field(

--- a/vulnclaw/web/services/provider_service.py
+++ b/vulnclaw/web/services/provider_service.py
@@ -50,34 +50,30 @@ def _normalize_base_url(value: str) -> str:
     return value.strip().rstrip("/").lower()
 
 
-def _is_trusted_base_url(base_url: str, config_base_url: str) -> bool:
-    """Only send the saved API key to a base_url we already trust.
-
-    The saved key must never be sent to an arbitrary client-supplied host: that
-    would let a malicious page (CSRF against this local API) exfiltrate the key
-    by pointing base_url at a server it controls. Restrict to the currently
-    saved base_url or one of the built-in provider presets.
-    """
-    normalized = _normalize_base_url(base_url)
-    if not normalized:
-        return False
-    if normalized == _normalize_base_url(config_base_url):
-        return True
-    trusted_urls = {
-        _normalize_base_url(str(preset.get("base_url", "")))
-        for preset in PROVIDER_PRESETS.values()
-        if preset.get("base_url")
-    }
-    return normalized in trusted_urls
+def _matches_saved_credential_scope(
+    request: ProviderModelsRequest,
+    base_url: str,
+    saved_provider: str,
+    saved_base_url: str,
+) -> bool:
+    """Return whether the request targets the saved credential's provider and URL."""
+    requested_provider = (request.provider or saved_provider).strip().lower()
+    requested_base_url = _normalize_base_url(base_url)
+    return (
+        bool(requested_provider)
+        and requested_provider == saved_provider.strip().lower()
+        and bool(requested_base_url)
+        and requested_base_url == _normalize_base_url(saved_base_url)
+    )
 
 
 def fetch_models(request: ProviderModelsRequest) -> ProviderModelsResponse:
     """List models for a provider/base URL using the saved API key.
 
     The key is read from the saved config (never accepted from the browser),
-    and is only ever sent to the saved base_url or a known provider preset —
-    never to an arbitrary client-supplied host — to avoid SSRF-style key
-    exfiltration via a spoofed base_url.
+    and is only sent when both the requested provider and base URL match the
+    saved configuration. This prevents cross-provider credential disclosure
+    and SSRF-style exfiltration through a spoofed base URL.
     Returns an empty list with a hint when no key is configured.
     """
     config = load_config()
@@ -92,14 +88,20 @@ def fetch_models(request: ProviderModelsRequest) -> ProviderModelsResponse:
             detail="No API key configured. Save your API key first, then refresh.",
         )
 
-    if not _is_trusted_base_url(base_url, config.llm.base_url):
+    if not _matches_saved_credential_scope(
+        request,
+        base_url,
+        config.llm.provider,
+        config.llm.base_url,
+    ):
         return ProviderModelsResponse(
             base_url=base_url,
             models=[],
             has_api_key=True,
             detail=(
-                "This base URL isn't saved or a known provider preset, so the saved "
-                "API key won't be sent to it. Save it first, then refresh."
+                "The requested provider and base URL don't match the saved provider "
+                "configuration, so the saved API key won't be sent. Save it first, "
+                "then refresh."
             ),
         )
 


### PR DESCRIPTION
Fixes #227. Replaces #145, which I closed myself because it targeted `main` instead of `dev` and bundled work well past the preset.

## What this is

Two changes, 120 insertions across five files.

**1. The preset** (`vulnclaw/config/schema.py`). One `LLMProvider.OPENROUTER` enum value and one `PROVIDER_PRESETS` entry:

```python
LLMProvider.OPENROUTER: {
    "base_url": "https://openrouter.ai/api/v1",
    "default_model": "anthropic/claude-sonnet-5",
    "label": "OpenRouter",
},
```

That is the whole integration. `make_openai_client`, `fetch_provider_models`, the CLI provider list, the Web Settings dropdown, and `apply_provider_preset()` are all data-driven off the enum and this dict, so OpenRouter appears everywhere with no per-provider branch. `.env.example` gains the matching base URL and model-ID examples.

The default model carries its vendor prefix on purpose: OpenRouter namespaces model IDs (`anthropic/claude-sonnet-5`, `openai/gpt-4o`), so a preset that copied OpenAI's bare `gpt-4o` would hand the user a config that 404s on its first request.

**2. The trust check the preset exposes** (`vulnclaw/web/services/provider_service.py`). `_is_trusted_base_url()` gated the saved API key on whether the requested base URL appeared in *any* preset, provider-blind:

```python
trusted_urls = {
    _normalize_base_url(str(preset.get("base_url", "")))
    for preset in PROVIDER_PRESETS.values()
    if preset.get("base_url")
}
return normalized in trusted_urls
```

`_resolve_base_url()` takes the URL straight from the request body, so on `dev` today a `POST /api/provider-models` carrying `base_url=https://api.deepseek.com` already forwards a saved OpenAI key to DeepSeek. Adding an aggregator preset puts `https://openrouter.ai/api/v1` into that set and makes it strictly worse — a CSRF against the local Web API can name it and exfiltrate whichever inference key the user saved, with no prompt and nothing visible in the UI. This replaces the allowlist with `_matches_saved_credential_scope()`: the key is sent only when the requested provider *and* base URL both equal the saved configuration.

## Anticipating the question from #145

The review question there was: OpenRouter already speaks the OpenAI API, so why adapt it separately. That is correct, and it is why this PR is small. #145 answered it by adding gateway-specific request/error/retry semantics, model-catalog tool-support filtering, and auth-mode clamps. None of that is here and none of it is needed for the preset to work. If tool-capability filtering on the OpenRouter catalog turns out to be wanted, it is a separate change against a separate issue.

## Behaviour change worth flagging

Model listing is now stricter, not looser. Previously the Settings "refresh models" button worked against any preset URL even when the saved key belonged to a different provider; now the user must save the provider and base URL first. The failure is explicit — an empty list with `"The requested provider and base URL don't match the saved provider configuration, so the saved API key won't be sent. Save it first, then refresh."` — rather than a silent cross-provider request. The `custom` provider is covered by a parametrized test to confirm a self-hosted endpoint still lists models once saved.

## Verification

```
$ ruff check vulnclaw tests
All checks passed!

$ python -m pytest -q
2 failed, 1429 passed, 1 skipped, 1 warning in 69.76s
```

The two failures are `tests/run/test_run_persistence.py::test_multi_target_run_seeds_secondary_state_and_resumes` and `::test_orchestrator_checkpoints_and_resumes_exact_run`. Correction: they are an artifact of my checkout location, not a defect in `dev`. That file writes snapshot paths roughly 190 characters below the repo root, so from a deeply nested working copy the writes exceed Windows `MAX_PATH` and fail with `FileNotFoundError` on the `.tmp` file. The same commit passes the full suite with zero failures from a short path (`C:cshort`). Nothing in this PR touches run persistence.

New coverage:

- `tests/config/test_config.py::test_openrouter_preset_uses_namespaced_default_model` — asserts the enum value, base URL, namespaced default, and label.
- `tests/web/test_web.py::test_web_provider_service_fetch_models_rejects_cross_provider_saved_key` — a saved DeepSeek key is not forwarded to `api.openai.com`.
- `tests/web/test_web.py::test_web_provider_service_fetch_models_rejects_saved_key_for_different_base_url` — a saved OpenAI key is not forwarded to `openrouter.ai`, the exact case the new preset would otherwise have opened.
- `tests/web/test_web.py::test_web_provider_service_fetch_models_uses_saved_key_for_matching_custom_base_url` — parametrized over `custom` and `openai`; the matching case still works.

`test_web_provider_service_fetch_models_honors_request_base_url` is replaced rather than deleted: it asserted the removed behaviour ("A known provider preset base_url is trusted and gets the saved key"), which is the bug.

No frontend changes; the Settings dropdown reads `/api/providers` and picks up the new preset without edits.


