### PR TITLE
fix(cli): answer readiness check-ins before starting an auto pentest

### DIFF
--- a/tests/cli/test_user_intent.py
+++ b/tests/cli/test_user_intent.py
@@ -35,6 +35,17 @@ class TestIsConversationalCheckin:
     def test_plain_work_order_not_checkin(self):
         assert is_conversational_checkin("recon crypto.com") is False
 
+    def test_operational_request_phrased_as_question_not_checkin(self):
+        # A concrete testing directive must still run, even without a URL and
+        # even when politely phrased as a question.
+        assert is_conversational_checkin("Can you test the login for SQL injection?") is False
+        assert is_conversational_checkin("could you check the upload form for XSS?") is False
+        assert is_conversational_checkin("能帮我测一下登录框的 SQL 注入吗？") is False
+
+    def test_readiness_question_still_checkin_even_with_action_word(self):
+        assert is_conversational_checkin("ready to begin bug hunting?") is True
+        assert is_conversational_checkin("should we start scanning now?") is True
+
 
 class TestShouldAutoPentestRespectsCheckin:
     def test_checkin_never_enters_auto_even_with_target(self):

--- a/tests/cli/test_user_intent.py
+++ b/tests/cli/test_user_intent.py
@@ -1,0 +1,55 @@
+"""Tests for conversational check-in routing helpers."""
+
+from vulnclaw.cli.main import _should_auto_pentest
+from vulnclaw.cli.user_intent import (
+    continue_task_prompt,
+    is_affirmative_continue,
+    is_conversational_checkin,
+)
+
+
+class TestIsConversationalCheckin:
+    def test_ready_to_begin_bug_hunting(self):
+        assert is_conversational_checkin("ready to begin bug hunting?") is True
+
+    def test_are_we_ready(self):
+        assert is_conversational_checkin("are we ready?") is True
+
+    def test_zh_readiness(self):
+        assert is_conversational_checkin("准备好开始了吗？") is True
+
+    def test_short_meta_question(self):
+        assert is_conversational_checkin("what's the plan?") is True
+
+    def test_affirmative_not_checkin(self):
+        assert is_conversational_checkin("yes") is False
+        assert is_affirmative_continue("yes") is True
+
+    def test_operational_with_url_not_checkin(self):
+        assert is_conversational_checkin("scan https://example.com for XSS?") is False
+
+    def test_imperative_start_not_checkin(self):
+        assert is_conversational_checkin("start recon") is False
+        assert is_conversational_checkin("scan it") is False
+
+    def test_plain_work_order_not_checkin(self):
+        assert is_conversational_checkin("recon crypto.com") is False
+
+
+class TestShouldAutoPentestRespectsCheckin:
+    def test_checkin_never_enters_auto_even_with_target(self):
+        assert _should_auto_pentest("ready to begin bug hunting?", "https://hackerone.com") is False
+
+    def test_explicit_recon_still_auto(self):
+        assert _should_auto_pentest("start recon", "https://api.example.com") is True
+
+
+class TestContinueTaskPrompt:
+    def test_uses_prior_task(self):
+        prompt = continue_task_prompt("/hackerone crypto", "https://hackerone.com")
+        assert "Prior task" in prompt
+        assert "crypto" in prompt
+
+    def test_fallback_to_target(self):
+        prompt = continue_task_prompt("yes", "https://web.crypto.com")
+        assert "web.crypto.com" in prompt

--- a/vulnclaw/cli/main.py
+++ b/vulnclaw/cli/main.py
@@ -572,7 +572,21 @@ def _run_repl() -> None:
                 console.print(_("cli.auto_mode_exited"))
                 is_auto_mode = False
             elif auto_mode_active:
-                is_auto_mode = True
+                from vulnclaw.cli.user_intent import (
+                    continue_task_prompt,
+                    is_affirmative_continue,
+                    is_conversational_checkin,
+                )
+
+                # Sticky auto mode must not swallow readiness check-ins
+                # ("ready to begin?") — answer first via single-turn chat.
+                if is_conversational_checkin(user_input):
+                    is_auto_mode = False
+                elif is_affirmative_continue(user_input):
+                    is_auto_mode = True
+                    user_input = continue_task_prompt(last_auto_input, current_target)
+                else:
+                    is_auto_mode = True
             else:
                 # Route to agent and detect whether this should be an autonomous loop
                 is_auto_mode = _should_auto_pentest(user_input, current_target)
@@ -2963,6 +2977,13 @@ def _should_auto_pentest(user_input: str, current_target: Optional[str]) -> bool
     - User asks for information gathering / recon / OSINT with a target
     - A target is present + multi-step task indicators
     """
+    from vulnclaw.cli.user_intent import is_conversational_checkin
+
+    # Readiness / meta questions (e.g. "ready to begin bug hunting?") get a
+    # spoken answer first — never jump straight into the solve tool loop.
+    if is_conversational_checkin(user_input):
+        return False
+
     input_lower = user_input.lower()
 
     # Explicit auto-mode triggers

--- a/vulnclaw/cli/user_intent.py
+++ b/vulnclaw/cli/user_intent.py
@@ -1,0 +1,110 @@
+"""Heuristics for REPL routing of conversational vs. operational user turns."""
+
+from __future__ import annotations
+
+import re
+
+_AFFIRMATIVE = frozenset(
+    {
+        "y",
+        "yes",
+        "yeah",
+        "yep",
+        "yup",
+        "ok",
+        "okay",
+        "sure",
+        "go",
+        "go ahead",
+        "proceed",
+        "continue",
+        "start",
+        "begin",
+        "do it",
+        "let's go",
+        "lets go",
+        "ship it",
+        "好",
+        "好的",
+        "行",
+        "可以",
+        "是",
+        "是的",
+        "继续",
+        "开始",
+        "干",
+        "搞起",
+    }
+)
+
+_READINESS_RE = re.compile(
+    r"(ready\s+to|are\s+(we|you)\s+ready|shall\s+we|should\s+we|"
+    r"can\s+we\s+(begin|start)|want\s+to\s+(begin|start)|good\s+to\s+go|"
+    r"all\s+set\??|"
+    r"准备好|可以开始|开始吗|开始么|开始了吗|要开始|开不开)",
+    re.IGNORECASE,
+)
+
+_URL_OR_IP_RE = re.compile(r"https?://|\b\d{1,3}(?:\.\d{1,3}){3}\b", re.IGNORECASE)
+
+_IMPERATIVE_START_RE = re.compile(
+    r"^(?:please\s+)?(?:"
+    r"go|start|continue|resume|scan|recon(?:naissance)?|test|pentest|"
+    r"exploit|enumerate|probe|fetch|check|run|do|"
+    r"扫描|测试|渗透|侦察|继续|开始"
+    r")\b",
+    re.IGNORECASE,
+)
+
+
+def is_affirmative_continue(user_input: str) -> bool:
+    """True when the user is green-lighting the next autonomous step."""
+    text = " ".join((user_input or "").strip().lower().split())
+    return text in _AFFIRMATIVE
+
+
+def is_conversational_checkin(user_input: str) -> bool:
+    """True when the user is asking a readiness/meta question, not issuing work.
+
+    Example: ``ready to begin bug hunting?`` should get a spoken status first,
+    not an immediate ``agent_run`` recon wave.
+    """
+    text = (user_input or "").strip()
+    if not text or is_affirmative_continue(text):
+        return False
+
+    if _READINESS_RE.search(text):
+        return True
+
+    is_question = "?" in text or text.endswith("？") or text.endswith("吗") or text.endswith("么")
+    if not is_question:
+        return False
+
+    # Operational questions with a concrete host stay on the work path.
+    if _URL_OR_IP_RE.search(text):
+        return False
+
+    # Short "scan it?"-style commands are not check-ins.
+    if _IMPERATIVE_START_RE.match(text) and len(text) <= 40:
+        return False
+
+    # Short open questions → answer first (status, plan, clarification).
+    return len(text) <= 120
+
+
+def continue_task_prompt(last_auto_input: str, current_target: str | None = None) -> str:
+    """Rewrite a terse affirmative into a full continue-task goal."""
+    prior = (last_auto_input or "").strip()
+    target = (current_target or "").strip()
+    if prior and not is_affirmative_continue(prior) and not is_conversational_checkin(prior):
+        return (
+            f"User confirmed: continue the prior autonomous engagement.\n"
+            f"Prior task: {prior}"
+            + (f"\nTarget: {target}" if target else "")
+        )
+    if target:
+        return (
+            f"User confirmed: begin or continue authorized recon and bug hunting "
+            f"on in-scope target {target}."
+        )
+    return "User confirmed: continue the current authorized engagement."

--- a/vulnclaw/cli/user_intent.py
+++ b/vulnclaw/cli/user_intent.py
@@ -56,6 +56,21 @@ _IMPERATIVE_START_RE = re.compile(
     re.IGNORECASE,
 )
 
+# An operational directive names a testing action, even when it is politely
+# phrased as a question and carries no URL ("can you test the login for SQLi?").
+# Readiness/meta questions are filtered out before this runs, so matching an
+# action verb anywhere in the turn is a signal to keep it on the work path.
+_OPERATIONAL_ACTION_RE = re.compile(
+    r"\b(?:scan|test|pentest|exploit|enumerate|probe|fuzz|attack|inject|"
+    r"brute(?:force|-force)?|recon(?:naissance)?)\b|"
+    # A named vulnerability class is itself a testing directive, so it keeps
+    # the turn operational even when the verb is a soft one like "check".
+    r"\b(?:sql\s*injection|sqli|xss|idor|ssrf|rce|csrf|lfi|rfi|xxe|ssti|"
+    r"open\s*redirect|path\s*traversal|command\s*injection)\b|"
+    r"扫描|测试|渗透|侦察|利用|爆破|枚举|注入",
+    re.IGNORECASE,
+)
+
 
 def is_affirmative_continue(user_input: str) -> bool:
     """True when the user is green-lighting the next autonomous step."""
@@ -86,6 +101,11 @@ def is_conversational_checkin(user_input: str) -> bool:
 
     # Short "scan it?"-style commands are not check-ins.
     if _IMPERATIVE_START_RE.match(text) and len(text) <= 40:
+        return False
+
+    # A concrete testing directive stays on the work path even without a host
+    # and even when phrased as a question ("can you test X for SQLi?").
+    if _OPERATIONAL_ACTION_RE.search(text):
         return False
 
     # Short open questions → answer first (status, plan, clarification).


### PR DESCRIPTION
Fixes #232. Split out of #231, where this change shared a branch with the setup wizard — it is unrelated to onboarding and is sent on its own rather than smuggled in under #160.

## Problem

Sticky auto mode routes every subsequent turn back into the autonomous loop with no test for whether the turn was a question:

```python
elif auto_mode_active:
    is_auto_mode = True
```

So "ready to begin bug hunting?" starts a scan. `_should_auto_pentest()` has the same gap on the entry path — a readiness question that names the target satisfies both its target check and its action-keyword check.

The consequence is tool calls, not just a wrong-looking reply: recon runs and requests go to the target, and sticky auto mode is precisely the state where confirmation prompts have been suppressed.

## Approach

`vulnclaw/cli/user_intent.py` separates conversational turns from operational ones:

- `is_conversational_checkin()` — readiness and meta questions, English and Chinese (`准备好了吗`, `可以开始了吗`)
- `is_affirmative_continue()` — the affirmatives that *should* still resume work (`yes`, `go ahead`, `继续`, `好的`, `行`)
- `continue_task_prompt()` — rebuilds the previous task's context when an affirmative resumes it

Both call sites consult it: the sticky-mode branch in `_run_repl()` and the early return in `_should_auto_pentest()`.

## Why not just check for a question mark

Because affirmatives have to keep working. `yes` / `继续` are the intended way to resume in sticky mode, and they carry no question mark but must still route to the loop *with the prior target context*. A punctuation test would fix check-ins by breaking continuation. The distinction that matters is conversational-vs-operational, and it has to hold in both languages the REPL supports.

## Scope

Three files: the new module, its tests, and two hunks in `vulnclaw/cli/main.py`. The module is pure — regex and frozenset membership, no I/O, no config — so `tests/cli/test_user_intent.py` covers it directly.

Anything that is neither a check-in nor an affirmative behaves exactly as before.

## Verification

```
ruff check vulnclaw tests              # All checks passed!
pytest -q tests/cli/test_user_intent.py # 12 passed
pytest -q                              # 1437 passed, 1 skipped, 2 failed
```

The two failures are `tests/run/test_run_persistence.py::test_multi_target_run_seeds_secondary_state_and_resumes` and `::test_orchestrator_checkpoints_and_resumes_exact_run`. Correction: they are an artifact of my checkout location, not a defect in `dev`. That file writes snapshot paths roughly 190 characters below the repo root, so from a deeply nested working copy the writes exceed Windows `MAX_PATH` and fail with `FileNotFoundError` on the `.tmp` file. The same commit passes the full suite with zero failures from a short path (`C:cshort`). Nothing in this PR touches run persistence.


