### PR TITLE
docs: add Discord community link to both READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 [![PyPI](https://img.shields.io/badge/PyPI-v0.3.8-blueviolet)](https://pypi.org/project/vulnclaw/)
 [![codecov](https://codecov.io/gh/Netw0rkNoob/VulnClaw/branch/main/graph/badge.svg)](https://codecov.io/gh/Netw0rkNoob/VulnClaw)
 [![Security](https://img.shields.io/badge/Scope-Authorized_Only-red)](#-安全声明)
+[![Discord](https://img.shields.io/badge/Discord-Join_Community-5865F2?logo=discord&logoColor=white)](https://discord.gg/q5nrZpe6S)
 [![AtomGitStars](https://atomgit.com/Unclecheng-li/VulnClaw/star/badge.svg)](https://atomgit.com/Unclecheng-li/VulnClaw)
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="https://kimi-file.moonshot.cn/prod-chat-kimi/kfs/4/1/2026-06-05/1d8h69mt3v89kkekg24gg">
@@ -23,6 +24,8 @@
 **本项目是可独立运行的 AI 渗透测试 Agent。**
 <br>
 项目官网：https://unclecheng-li.github.io/vulnclaw.com/
+<br>
+💬 **社区**: [加入我们的 Discord](https://discord.gg/q5nrZpe6S)
 <br>
 
 基于 LLM Agent + MCP 工具链 + 可选 Skill 参考资料，

--- a/README_EN.md
+++ b/README_EN.md
@@ -11,6 +11,7 @@
 [![PyPI](https://img.shields.io/badge/PyPI-v0.3.8-blueviolet)](https://pypi.org/project/vulnclaw/)
 [![codecov](https://codecov.io/gh/Netw0rkNoob/VulnClaw/branch/main/graph/badge.svg)](https://codecov.io/gh/Netw0rkNoob/VulnClaw)
 [![Security](https://img.shields.io/badge/Scope-Authorized_Only-red)](#-security-notice)
+[![Discord](https://img.shields.io/badge/Discord-Join_Community-5865F2?logo=discord&logoColor=white)](https://discord.gg/q5nrZpe6S)
 [![AtomGitStars](https://atomgit.com/Unclecheng-li/VulnClaw/star/badge.svg)](https://atomgit.com/Unclecheng-li/VulnClaw)
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="https://kimi-file.moonshot.cn/prod-chat-kimi/kfs/4/1/2026-06-05/1d8h69mt3v89kkekg24gg">
@@ -23,6 +24,8 @@
 **This project is a standalone AI penetration testing Agent.**
 <br>
 Official Website: https://unclecheng-li.github.io/vulnclaw.com/
+<br>
+💬 **Community**: [Join our Discord](https://discord.gg/q5nrZpe6S)
 <br>
 
 Built on LLM Agent + MCP Toolchain + optional Skill reference material,


### PR DESCRIPTION
Closes #241. Follow-up to #170.

## Summary

The Discord community from #170 (https://discord.gg/q5nrZpe6S) was reachable only through that closed issue. This adds it to both READMEs so it sits alongside the existing badges and links.

## Changes

- `README.md` and `README_EN.md`: `Discord` badge in the badge block, next to `Security`
- Both files: a `💬 Community` / `💬 社区` line under the official-website line in the header block

The English README already carried these two elements in the fork; this PR brings `dev` to parity and adds the Chinese equivalents so neither README trails the other.

## Verification

Docs-only, no code paths touched. Rendered both files locally; badge and link resolve to the #170 invite.