### PR TITLE
feat(config): add OrcaRouter provider preset and scope saved key to its provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,11 +12,12 @@
 # Required: API key for your provider.
 VULNCLAW_LLM_API_KEY=sk-your-key-here
 
-# Provider label (openai, anthropic, deepseek, zhipu, minimax, moonshot, qwen, ...).
+# Provider label (openai, orcarouter, anthropic, deepseek, zhipu, minimax, moonshot, qwen, ...).
 VULNCLAW_LLM_PROVIDER=openai
 
 # API base URL — MUST match your key's provider. Examples:
 #   OpenAI     https://api.openai.com/v1
+#   OrcaRouter https://api.orcarouter.ai/v1
 #   Anthropic  https://api.anthropic.com/v1
 #   DeepSeek   https://api.deepseek.com
 #   Zhipu      https://open.bigmodel.cn/api/paas/v4
@@ -24,8 +25,9 @@ VULNCLAW_LLM_PROVIDER=openai
 #   Qwen       https://dashscope.aliyuncs.com/compatible-mode/v1
 VULNCLAW_LLM_BASE_URL=https://api.openai.com/v1
 
-# Model name — MUST match the provider above (e.g. gpt-4o, deepseek-chat,
-# claude-sonnet-5, glm-4.7, kimi-k2.6, qwen3-max).
+# Model name — MUST match the provider above (e.g. gpt-4o,
+# claude-sonnet-5 for Anthropic, orcarouter/auto for OrcaRouter,
+# deepseek-chat, glm-4.7, kimi-k2.6, qwen3-max).
 VULNCLAW_LLM_MODEL=gpt-4o
 
 # Optional: token / sampling tuning.

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ VulnClaw 自动执行：
 - **轻量纠偏层** — 工具调用前后记录重复调用、失败降级、耗时和新发现等信号；重复读取同一 evidence 范围会被抑制，连续证据空转会触发 stall guard，但不恢复旧阶段规划器
 - **证据级反幻觉闸门** — 声称的 flag/结论必须在真实工具输出里逐字符出现才被采信，杜绝凭空编造 flag 的假胜利
 - **自然语言驱动** — 用人话描述渗透意图，自动识别阶段和工具
-- **14 个 LLM Provider** — OpenAI / Anthropic / MiniMax / DeepSeek / 智谱 / Moonshot / 千问 / SiliconFlow / 豆包 / 百川 / 阶跃星辰 / 商汤 / 零一万物 / 本地 Ollama，一键切换
+- **15 个 LLM Provider** — OpenAI / Anthropic / MiniMax / DeepSeek / 智谱 / Moonshot / 千问 / SiliconFlow / 豆包 / 百川 / 阶跃星辰 / 商汤 / 零一万物 / OrcaRouter / 本地 Ollama，一键切换
 - **MCP 工具链** — 4 个 MCP 服务：`fetch` / `memory` 本地实现开箱即用，`chrome-devtools` / `burp` 对接外部 MCP 服务实现浏览器自动化和 HTTP 抓包重放
 - **增强 fetch 请求工具** — 默认直接 GET 并返回完整响应 body，支持 HTTP/HTTPS、自定义 method/headers/params/cookies/body/data/form/json、timeout/redirect/TLS 控制；CTF/靶场 HTTPS 默认不校验证书
 - **原生流量证据存储** — 按运行内作用域过滤后以追加式 JSONL 索引 + 每请求原始报文落盘于 `evidence/traffic/`，内置 `traffic_list` / `traffic_view` / `traffic_repeat` / `traffic_sitemap` 工具直接读写
@@ -380,7 +380,7 @@ FINAL 经过证据闸门校验 → 通过才结束，否则把拒绝原因返回
 | **插件体系** | `plugins/` | 低耦合漏洞检测插件运行时 |
 | **Skill 参考索引** | `skills/loader.py` + `resolver.py` | 只解析相关参考资料，不注入强制流程 |
 | **MCP 编排** | `mcp/registry.py` + `lifecycle.py` + `router.py` | 服务注册 + 生命周期 + 工具路由 |
-| **配置管理** | `config/schema.py` + `settings.py` | Pydantic + YAML + 13 Provider 预设 |
+| **配置管理** | `config/schema.py` + `settings.py` | Pydantic + YAML + 14 Provider 预设 |
 | **报告生成** | `report/generator.py` + `poc_builder.py` | Markdown 报告 + PoC 脚本 |
 | **安全知识库** | `kb/store.py` + `retriever.py` | JSON 存储 + CVE/技术/工具检索 |
 
@@ -539,6 +539,7 @@ vulnclaw config provider minimax   # 一键切换
 | 阶跃星辰 | `provider stepfun` | step-3.5-flash |
 | 商汤 | `provider sensetime` | SenseNova-6.7-Flash-Lite |
 | 零一万物 | `provider yi` | yi-lightning |
+| OrcaRouter | `provider orcarouter` | orcarouter/auto |
 | Ollama (本地) | `provider ollama` | llama3.1 |
 | 自定义 | `provider custom` | 手动填写 |
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -68,7 +68,7 @@ Suitable for authorized pentests, CTF competitions, security training, and red t
 - **Lightweight Correction Layer** — Records repeated calls, degraded tools, timing, and new observations; repeated reads of the same evidence range are suppressed and evidence-only stalls trigger a stall guard without restoring the old stage planner
 - **Evidence-Level Anti-Hallucination Gate** — Claims about flags/conclusions must appear verbatim in real tool output to be accepted; prevents fabricated flags
 - **Natural Language Driven** — Describe your goal in plain English, auto-identifies phases and tools
-- **14 LLM Providers** — OpenAI / Anthropic / MiniMax / DeepSeek / Zhipu / Moonshot / Qwen / SiliconFlow / Doubao / Baichuan / StepFun / SenseTime / Yi / local Ollama, one-command switch
+- **15 LLM Providers** — OpenAI / Anthropic / MiniMax / DeepSeek / Zhipu / Moonshot / Qwen / SiliconFlow / Doubao / Baichuan / StepFun / SenseTime / Yi / OrcaRouter / local Ollama, one-command switch
 - **MCP Toolchain** — 4 MCP services: `fetch` / `memory` run locally out-of-the-box, `chrome-devtools` / `burp` connect to external MCP servers for browser automation and HTTP interception
 - **Enhanced fetch request tool** — Defaults to GET, returns the full response body, and supports HTTP/HTTPS, custom method/headers/params/cookies/body/data/form/json, timeout/redirect/TLS controls; TLS verification is off by default for CTF/lab HTTPS targets
 - **Native Traffic Evidence Store** — In-scope request/response pairs land in an append-only JSONL index under `evidence/traffic/`. Built-in `traffic_list` / `traffic_view` / `traffic_repeat` / `traffic_sitemap` tools read and replay the store
@@ -388,7 +388,7 @@ FINAL passes evidence gate → accepted; otherwise the rejection is fed back and
 | **Plugin System** | `plugins/` | Low-coupling vulnerability detection plugin runtime |
 | **Skill reference index** | `skills/loader.py` + `resolver.py` | Task-aware optional references without forced workflow injection |
 | **MCP Orchestration** | `mcp/registry.py` + `lifecycle.py` + `router.py` | Service registry + lifecycle + tool routing |
-| **Config** | `config/schema.py` + `settings.py` | Pydantic + YAML + 14 provider presets + SubagentConfig |
+| **Config** | `config/schema.py` + `settings.py` | Pydantic + YAML + 15 provider presets + SubagentConfig |
 | **Report Generator** | `report/generator.py` + `poc_builder.py` | Markdown reports + PoC scripts |
 | **Security KB** | `kb/store.py` + `retriever.py` | JSON storage + CVE/technique/tool retrieval |
 
@@ -547,6 +547,7 @@ vulnclaw config provider minimax   # one-command switch
 | StepFun | `provider stepfun` | step-3.5-flash |
 | SenseTime | `provider sensetime` | SenseNova-6.7-Flash-Lite |
 | Yi | `provider yi` | yi-lightning |
+| OrcaRouter | `provider orcarouter` | orcarouter/auto |
 | Ollama (local) | `provider ollama` | llama3.1 |
 | Custom | `provider custom` | manual |
 

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -293,6 +293,19 @@ class TestVulnClawConfig:
         assert preset["default_model"] == "llama3.1"
         assert preset["label"]
 
+    def test_orcarouter_preset_uses_routed_default_model(self):
+        """OrcaRouter is an aggregator: one OpenAI-compatible endpoint fronting
+        many vendors with adaptive routing, so model IDs carry a ``vendor/model``
+        prefix and the default is the routing entry point. No provider-specific
+        code path is needed beyond the preset."""
+        from vulnclaw.config.schema import PROVIDER_PRESETS, LLMProvider
+
+        assert LLMProvider("orcarouter") is LLMProvider.ORCAROUTER
+        preset = PROVIDER_PRESETS[LLMProvider.ORCAROUTER]
+        assert preset["base_url"] == "https://api.orcarouter.ai/v1"
+        assert preset["default_model"] == "orcarouter/auto"
+        assert preset["label"] == "OrcaRouter"
+
     def test_llm_provider_enum(self):
         from vulnclaw.config.schema import LLMProvider
 

--- a/tests/web/test_web.py
+++ b/tests/web/test_web.py
@@ -154,31 +154,85 @@ class TestWebServices:
         assert resp.models == []
         assert "key" in resp.detail.lower()
 
-    def test_web_provider_service_fetch_models_honors_request_base_url(self, monkeypatch):
+    def test_web_provider_service_fetch_models_rejects_cross_provider_saved_key(self, monkeypatch):
         import vulnclaw.web.services.provider_service as provider_service
         from vulnclaw.config.schema import VulnClawConfig
         from vulnclaw.web.schemas import ProviderModelsRequest
 
         config = VulnClawConfig()
-        config.llm.api_key = "sk-test"
-        config.llm.base_url = "https://config-default.example/v1"
+        config.llm.provider = "deepseek"
+        config.llm.api_key = "sk-deepseek"
+        config.llm.base_url = "https://api.deepseek.com/v1"
+        monkeypatch.setattr(provider_service, "load_config", lambda: config)
+
+        def must_not_call(*args, **kwargs):
+            raise AssertionError("a saved key must not cross provider boundaries")
+
+        monkeypatch.setattr(provider_service, "fetch_provider_models", must_not_call)
+
+        resp = provider_service.fetch_models(
+            ProviderModelsRequest(provider="openai", base_url="https://api.openai.com/v1")
+        )
+        assert resp.base_url == "https://api.openai.com/v1"
+        assert resp.models == []
+        assert resp.has_api_key is True
+        assert "saved provider" in resp.detail.lower()
+
+    def test_web_provider_service_fetch_models_rejects_saved_key_for_different_base_url(
+        self, monkeypatch
+    ):
+        import vulnclaw.web.services.provider_service as provider_service
+        from vulnclaw.config.schema import VulnClawConfig
+        from vulnclaw.web.schemas import ProviderModelsRequest
+
+        config = VulnClawConfig()
+        config.llm.provider = "openai"
+        config.llm.api_key = "sk-openai"
+        config.llm.base_url = "https://api.openai.com/v1"
+        monkeypatch.setattr(provider_service, "load_config", lambda: config)
+
+        def must_not_call(*args, **kwargs):
+            raise AssertionError("a saved key must not cross base URL boundaries")
+
+        monkeypatch.setattr(provider_service, "fetch_provider_models", must_not_call)
+
+        resp = provider_service.fetch_models(
+            ProviderModelsRequest(provider="openai", base_url="https://api.orcarouter.ai/v1")
+        )
+        assert resp.models == []
+        assert resp.has_api_key is True
+        assert "base url" in resp.detail.lower()
+
+    @pytest.mark.parametrize("saved_provider", ["custom", "openai"])
+    def test_web_provider_service_fetch_models_uses_saved_key_for_matching_custom_base_url(
+        self, monkeypatch, saved_provider
+    ):
+        import vulnclaw.web.services.provider_service as provider_service
+        from vulnclaw.config.schema import VulnClawConfig
+        from vulnclaw.web.schemas import ProviderModelsRequest
+
+        config = VulnClawConfig()
+        config.llm.provider = saved_provider
+        config.llm.api_key = "sk-custom"
+        config.llm.base_url = "https://llm.example.com/v1/"
         monkeypatch.setattr(provider_service, "load_config", lambda: config)
 
         captured = {}
 
         def fake_fetch(base_url, api_key, timeout=10.0):
-            captured["base_url"] = base_url
-            return ["m"]
+            captured.update(base_url=base_url, api_key=api_key)
+            return ["custom-model"]
 
         monkeypatch.setattr(provider_service, "fetch_provider_models", fake_fetch)
 
-        # A known provider preset base_url is trusted and gets the saved key.
         resp = provider_service.fetch_models(
-            ProviderModelsRequest(base_url="https://api.openai.com/v1")
+            ProviderModelsRequest(provider=saved_provider, base_url="https://llm.example.com/v1")
         )
-        assert captured["base_url"] == "https://api.openai.com/v1"
-        assert resp.base_url == "https://api.openai.com/v1"
-        assert resp.models == ["m"]
+        assert resp.models == ["custom-model"]
+        assert captured == {
+            "base_url": "https://llm.example.com/v1",
+            "api_key": "sk-custom",
+        }
 
     def test_web_provider_service_fetch_models_rejects_untrusted_base_url(self, monkeypatch):
         """An arbitrary client-supplied base_url must never receive the saved API key."""

--- a/vulnclaw/config/schema.py
+++ b/vulnclaw/config/schema.py
@@ -27,6 +27,7 @@ class LLMProvider(str, Enum):
     STEPFUN = "stepfun"
     SENSETIME = "sensetime"
     YI = "yi"
+    ORCAROUTER = "orcarouter"
     OLLAMA = "ollama"
     CUSTOM = "custom"
 
@@ -98,6 +99,15 @@ PROVIDER_PRESETS: dict[LLMProvider, dict[str, str]] = {
         "default_model": "yi-lightning",
         "label": "零一万物 (Yi)",
     },
+    # Aggregator fronting many vendors behind one OpenAI-compatible endpoint.
+    # Model IDs are namespaced by vendor (anthropic/..., openai/..., ...), so the
+    # default carries its vendor prefix. Pick a tool-capable model — VulnClaw
+    # drives everything through function calls.
+    LLMProvider.ORCAROUTER: {
+        "base_url": "https://api.orcarouter.ai/v1",
+        "default_model": "orcarouter/auto",
+        "label": "OrcaRouter",
+    },
     # Local models via Ollama's OpenAI-compatible endpoint. No API key is
     # required (the client sends a placeholder). The default model must support
     # tool calling — VulnClaw drives everything through function calls — so pick
@@ -121,7 +131,7 @@ class LLMConfig(BaseModel):
 
     provider: str = Field(
         default="openai",
-        description="LLM provider name (openai/anthropic/minimax/deepseek/zhipu/moonshot/qwen/siliconflow/doubao/baichuan/stepfun/sensetime/yi/ollama/custom)",
+        description="LLM provider name (openai/anthropic/minimax/deepseek/zhipu/moonshot/qwen/siliconflow/doubao/baichuan/stepfun/sensetime/yi/orcarouter/ollama/custom)",
     )
     api_key: str = Field(default="", description="Static API key for the chosen provider (auth_mode=static)")
     api_keys: list[str] = Field(

--- a/vulnclaw/web/services/provider_service.py
+++ b/vulnclaw/web/services/provider_service.py
@@ -50,34 +50,30 @@ def _normalize_base_url(value: str) -> str:
     return value.strip().rstrip("/").lower()
 
 
-def _is_trusted_base_url(base_url: str, config_base_url: str) -> bool:
-    """Only send the saved API key to a base_url we already trust.
-
-    The saved key must never be sent to an arbitrary client-supplied host: that
-    would let a malicious page (CSRF against this local API) exfiltrate the key
-    by pointing base_url at a server it controls. Restrict to the currently
-    saved base_url or one of the built-in provider presets.
-    """
-    normalized = _normalize_base_url(base_url)
-    if not normalized:
-        return False
-    if normalized == _normalize_base_url(config_base_url):
-        return True
-    trusted_urls = {
-        _normalize_base_url(str(preset.get("base_url", "")))
-        for preset in PROVIDER_PRESETS.values()
-        if preset.get("base_url")
-    }
-    return normalized in trusted_urls
+def _matches_saved_credential_scope(
+    request: ProviderModelsRequest,
+    base_url: str,
+    saved_provider: str,
+    saved_base_url: str,
+) -> bool:
+    """Return whether the request targets the saved credential's provider and URL."""
+    requested_provider = (request.provider or saved_provider).strip().lower()
+    requested_base_url = _normalize_base_url(base_url)
+    return (
+        bool(requested_provider)
+        and requested_provider == saved_provider.strip().lower()
+        and bool(requested_base_url)
+        and requested_base_url == _normalize_base_url(saved_base_url)
+    )
 
 
 def fetch_models(request: ProviderModelsRequest) -> ProviderModelsResponse:
     """List models for a provider/base URL using the saved API key.
 
     The key is read from the saved config (never accepted from the browser),
-    and is only ever sent to the saved base_url or a known provider preset —
-    never to an arbitrary client-supplied host — to avoid SSRF-style key
-    exfiltration via a spoofed base_url.
+    and is only sent when both the requested provider and base URL match the
+    saved configuration. This prevents cross-provider credential disclosure
+    and SSRF-style exfiltration through a spoofed base URL.
     Returns an empty list with a hint when no key is configured.
     """
     config = load_config()
@@ -92,14 +88,20 @@ def fetch_models(request: ProviderModelsRequest) -> ProviderModelsResponse:
             detail="No API key configured. Save your API key first, then refresh.",
         )
 
-    if not _is_trusted_base_url(base_url, config.llm.base_url):
+    if not _matches_saved_credential_scope(
+        request,
+        base_url,
+        config.llm.provider,
+        config.llm.base_url,
+    ):
         return ProviderModelsResponse(
             base_url=base_url,
             models=[],
             has_api_key=True,
             detail=(
-                "This base URL isn't saved or a known provider preset, so the saved "
-                "API key won't be sent to it. Save it first, then refresh."
+                "The requested provider and base URL don't match the saved provider "
+                "configuration, so the saved API key won't be sent. Save it first, "
+                "then refresh."
             ),
         )
 


### PR DESCRIPTION
## What this is

VulnClaw calls itself an *AI-powered penetration testing CLI tool* whose model-led solve engine "drives everything through function calls". Out of the box it ships **15 provider presets** — OpenAI / Anthropic / MiniMax / DeepSeek / Zhipu / Moonshot / Qwen / SiliconFlow / Doubao / Baichuan / StepFun / SenseTime / Yi / OrcaRouter / local Ollama — and lets you `vulnclaw config provider <name>` to one-command switch, auto-filling Base URL and model name.

Until now, if you wanted to run VulnClaw against a gateway like OpenRouter or OrcaRouter, you had to fall back to `provider custom` and hand-type the base URL into every config. This PR makes OrcaRouter a first-class preset, exactly mirroring the existing OpenAI-compatible presets — one enum value and one `PROVIDER_PRESETS` entry, no per-provider branch:

```python
LLMProvider.ORCAROUTER: {
    "base_url": "https://api.orcarouter.ai/v1",
    "default_model": "orcarouter/auto",
    "label": "OrcaRouter",
},
```

The default model carries its vendor prefix on purpose: OrcaRouter, like OpenRouter, is an aggregator fronting many vendors behind one OpenAI-compatible endpoint, and its model IDs are namespaced (`orcarouter/auto` is the adaptive-routing entry point, alongside `qwen/...`, `deepseek/...`, `anthropic/...`). A preset that copied a bare model name would hand the user a config that 404s on its first request.

`make_openai_client`, `fetch_provider_models`, the CLI provider list, the manual page, and the Web Settings dropdown are all data-driven off the enum and this dict, so OrcaRouter appears everywhere with no per-provider branch — the same wiring that already exposes every other preset.

## The trust check the preset exposes

`vulnclaw/web/services/provider_service.py` gates the saved API key on whether the requested base URL appears in *any* preset, provider-blind:

```python
trusted_urls = {
    _normalize_base_url(str(preset.get("base_url", "")))
    for preset in PROVIDER_PRESETS.values()
    if preset.get("base_url")
}
return normalized in trusted_urls
```

Adding an aggregator preset puts `https://api.orcarouter.ai/v1` into that set and makes it strictly worse: a CSRF against the local Web API could name it and exfiltrate whichever inference key the user saved, with no prompt and nothing visible in the UI. This replaces the allowlist with `_matches_saved_credential_scope()` — the key is sent only when the requested provider *and* base URL both equal the saved configuration. Same tightening #229 applied for the OpenRouter preset, applied here so OrcaRouter arrives without re-opening that hole.

## Behaviour change worth flagging

Model listing is stricter, not looser: previously the Settings "refresh models" button worked against any preset URL even when the saved key belonged to a different provider; now the user must save the provider and base URL first. The failure is explicit — an empty list with *"The requested provider and base URL don't match the saved provider configuration, so the saved API key won't be sent. Save it first, then refresh."* — rather than a silent cross-provider request. The `custom` provider is covered by a parametrized test to confirm a self-hosted endpoint still lists models once saved.

## Verification

```
$ python -m ruff check .
All checks passed!

$ python -m pytest -q
1 failed, 1351 passed, 4 skipped in 20.51s
```

The single failure is `tests/agent/test_builtin_tools.py::test_shell_command_runs_local_verification_and_returns_full_output`, which is pre-existing in this checkout and unrelated to this PR: it invokes `python -c "..."` through a `cmd`-style shell and this Linux container only ships `python3` (`/bin/sh: 1: python: not found`). I confirmed it fails identically on a clean `main` with this PR's changes stashed.

Live check against the real endpoint: resolved the preset through `apply_provider_preset` and issued one ChatCompletion against `https://api.orcarouter.ai/v1` with `orcarouter/auto` using the OpenAI SDK — `HTTP ok. choices=1`, using the project's own provider-resolution path. (The reply was truncated only because the check set `max_tokens=8`.)

New coverage:

- `tests/config/test_config.py::test_orcarouter_preset_uses_routed_default_model` — asserts the enum value, base URL, namespaced default, and label.
- `tests/web/test_web.py::test_web_provider_service_fetch_models_rejects_cross_provider_saved_key` — a saved DeepSeek key is not forwarded to `api.openai.com`.
- `tests/web/test_web.py::test_web_provider_service_fetch_models_rejects_saved_key_for_different_base_url` — a saved OpenAI key is not forwarded to `api.orcarouter.ai`, the exact case the new preset would otherwise have opened.
- `tests/web/test_web.py::test_web_provider_service_fetch_models_uses_saved_key_for_matching_custom_base_url` — parametrized over `custom` and `openai`; the matching case still works.

`test_web_provider_service_fetch_models_honors_request_base_url` is replaced rather than deleted: it asserted the removed behaviour ("a known provider preset base_url is trusted and gets the saved key"), which is the bug.

No frontend changes; the Settings dropdown reads `/api/providers` and picks up the new preset without edits.

---

[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding orcarouter as a first-class provider means this project's users can use that stack directly, without treating OrcaRouter as an anonymous custom base URL. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter

I'm an engineer on the OrcaRouter team.
