### PR TITLE
Fix: surface LLM chat errors instead of swallowing them silently

### DIFF
--- a/vulnclaw/cli/main.py
+++ b/vulnclaw/cli/main.py
@@ -703,9 +703,12 @@ def _run_repl() -> None:
                                     current_target = result.target
                                 if result.phase:
                                     current_phase = result.phase
-                                # 注释掉: 流式输出已通过 TerminalStreamSink 实时显示，无需重复打印
-                                # if result.output:
-                                #     _print_agent_output(result.output, config)
+                                # 流式输出已通过 TerminalStreamSink 实时显示，无需重复打印；
+                                # 但 agent.chat() 在 LLM 调用异常时不会流式输出任何 token，
+                                # 错误信息只落在 result.output 里，这里必须打印出来，
+                                # 否则用户只会看到 "Thinking..." 后静默回到提示符。
+                                if result.output and result.output.startswith("[!]"):
+                                    _print_agent_output(result.output, config)
 
                         await _run_repl_agent_call(agent, call=call, after_result=after_result)
 


### PR DESCRIPTION
## Summary
- `agent.chat()` catches its LLM call exception and stores the message in `result.output` (`vulnclaw/agent/core.py:511-512`), but the REPL's single-turn chat `after_result` handler had that print commented out, assuming streaming already displayed the content.
- That assumption fails whenever the call errors *before* any token streams (bad model id, invalid key, network error, etc.) — the REPL just shows `Thinking...` and silently returns to the prompt with zero error text and no session/run file to inspect.
- Fix: print `result.output` when it carries the `"[!]"` error prefix, leaving the normal streamed-output path (which already renders via `TerminalStreamSink`) untouched.

Fixes #248

## Test plan
- [x] `python -m py_compile vulnclaw/cli/main.py`
- [x] Manually reproduced: configured provider/model combo that fails the LLM call, confirmed `vulnclaw` REPL previously showed nothing after "Thinking...", and now prints the `[!] Agent 错误: ...` message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013eUxo8KY1ZdYX6wx42zC8v