### PR TITLE
feat(kb): 中文感知 BM25 检索 + 可选 cross-encoder 重排序

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,7 +401,7 @@ FINAL 经过证据闸门校验 → 通过才结束，否则把拒绝原因返回
 | **MCP 编排** | `mcp/registry.py` + `lifecycle.py` + `router.py` | 服务注册 + 生命周期 + 工具路由 |
 | **配置管理** | `config/schema.py` + `settings.py` | Pydantic + YAML + 13 Provider 预设 |
 | **报告生成** | `report/generator.py` + `poc_builder.py` | Markdown 报告 + PoC 脚本 |
-| **安全知识库** | `kb/store.py` + `retriever.py` | JSON 存储 + CVE/技术/工具检索 |
+| **安全知识库** | `kb/store.py` + `retriever.py` + `ranking.py` | JSON 存储 + 中文感知 BM25 检索 + 可选重排序 |
 
 ---
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -410,7 +410,7 @@ FINAL passes evidence gate → accepted; otherwise the rejection is fed back and
 | **MCP Orchestration** | `mcp/registry.py` + `lifecycle.py` + `router.py` | Service registry + lifecycle + tool routing |
 | **Config** | `config/schema.py` + `settings.py` | Pydantic + YAML + 14 provider presets + SubagentConfig |
 | **Report Generator** | `report/generator.py` + `poc_builder.py` | Markdown reports + PoC scripts |
-| **Security KB** | `kb/store.py` + `retriever.py` | JSON storage + CVE/technique/tool retrieval |
+| **Security KB** | `kb/store.py` + `retriever.py` + `ranking.py` | JSON storage + Chinese-aware BM25 retrieval + optional reranking |
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,10 @@ web = [
 kb = [
     "chromadb>=0.4.0",
 ]
+rerank = [
+    # Optional: cross-encoder precision stage for the keyword KB backend.
+    "sentence-transformers>=2.2.0",
+]
 pdf = [
     # Optional: render reports to PDF via report.pdf_exporter.
     "reportlab>=4.0",

--- a/tests/kb/test_kb_fallback.py
+++ b/tests/kb/test_kb_fallback.py
@@ -81,6 +81,15 @@ class TestKeywordRetriever:
         assert results, "expected at least one keyword match"
         assert results[0]["id"] == "sqli-bypass"
 
+    def test_retrieve_chinese_query_finds_chinese_entry(self, tmp_path):
+        store = _seed_store(tmp_path)
+        kw = KeywordRetriever(store)
+
+        # The old [a-z0-9]+ tokenizer dropped CJK entirely, so this returned [].
+        results = kw.retrieve("注入绕过", top_k=3)
+        assert results, "expected Chinese query to match Chinese KB entries"
+        assert results[0]["id"] == "sqli-bypass"
+
     def test_retrieve_matches_cve_by_service(self, tmp_path):
         store = _seed_store(tmp_path)
         kw = KeywordRetriever(store)

--- a/tests/kb/test_ranking.py
+++ b/tests/kb/test_ranking.py
@@ -1,0 +1,156 @@
+"""Tests for the Chinese-aware KB ranking primitives (ranking.py + glue)."""
+
+
+# ── bigram_tokenize ──────────────────────────────────────────────────
+
+
+class TestBigramTokenize:
+    def test_chinese_produces_bigrams(self):
+        from vulnclaw.kb.ranking import bigram_tokenize
+
+        # The old [a-z0-9]+ tokenizer returned only ["sql"], dropping all CJK.
+        assert bigram_tokenize("SQL 注入绕过") == ["sql", "注入", "入绕", "绕过"]
+
+    def test_latin_runs_stay_whole(self):
+        from vulnclaw.kb.ranking import bigram_tokenize
+
+        assert bigram_tokenize("sql injection waf bypass") == [
+            "sql",
+            "injection",
+            "waf",
+            "bypass",
+        ]
+
+    def test_cjk_run_overlaps(self):
+        from vulnclaw.kb.ranking import bigram_tokenize
+
+        assert bigram_tokenize("注入绕过") == ["注入", "入绕", "绕过"]
+
+    def test_single_cjk_char_emitted_alone(self):
+        from vulnclaw.kb.ranking import bigram_tokenize
+
+        assert bigram_tokenize("中") == ["中"]
+
+    def test_empty_string(self):
+        from vulnclaw.kb.ranking import bigram_tokenize
+
+        assert bigram_tokenize("") == []
+
+    def test_punctuation_acts_as_separator(self):
+        from vulnclaw.kb.ranking import bigram_tokenize
+
+        assert bigram_tokenize("WAF;注入,绕过") == ["waf", "注入", "绕过"]
+
+
+# ── BM25 ─────────────────────────────────────────────────────────────
+
+
+class TestBM25:
+    DOCS = [
+        "SQL 注入绕过 WAF 技巧",
+        "PHP 命令执行绕过技巧",
+        "Nmap 端口扫描速查",
+    ]
+
+    def test_chinese_query_ranks_relevant_first(self):
+        from vulnclaw.kb.ranking import BM25
+
+        ranked = BM25(self.DOCS).search("注入绕过", top_k=3)
+        assert ranked and ranked[0][0] == 0  # "SQL 注入绕过 WAF 技巧"
+
+    def test_english_query_matches_latin_tokens(self):
+        from vulnclaw.kb.ranking import BM25
+
+        ranked = BM25(self.DOCS).search("nmap port scan", top_k=3)
+        assert ranked and ranked[0][0] == 2  # "Nmap 端口扫描速查"
+
+    def test_empty_query_returns_empty(self):
+        from vulnclaw.kb.ranking import BM25
+
+        assert BM25(self.DOCS).search("", top_k=3) == []
+
+    def test_no_match_returns_empty(self):
+        from vulnclaw.kb.ranking import BM25
+
+        assert BM25(self.DOCS).search("zzzzz_nonexistent", top_k=3) == []
+
+    def test_top_k_truncation(self):
+        from vulnclaw.kb.ranking import BM25
+
+        ranked = BM25(self.DOCS).search("绕过", top_k=1)
+        assert len(ranked) == 1
+
+
+# ── RerankedRetriever (two-stage glue) ───────────────────────────────
+
+
+class _FakeBase:
+    def __init__(self, entries):
+        self._entries = entries
+
+    def has_data(self):
+        return bool(self._entries)
+
+    def retrieve(self, query, top_k=5):
+        return self._entries[:top_k]
+
+
+class _FakeReranker:
+    def __init__(self, available=True, order=None):
+        self.available = available
+        self._order = order or []
+
+    def rerank(self, query, texts, top_k):
+        return self._order[:top_k]
+
+
+class TestRerankedRetriever:
+    def test_unavailable_reranker_returns_base_ranking(self):
+        from vulnclaw.kb.retriever import RerankedRetriever
+
+        entries = [{"id": "a"}, {"id": "b"}, {"id": "c"}]
+        rr = RerankedRetriever(_FakeBase(entries), _FakeReranker(available=False))
+        assert [e["id"] for e in rr.retrieve("query", top_k=2)] == ["a", "b"]
+
+    def test_available_reranker_reorders(self):
+        from vulnclaw.kb.retriever import RerankedRetriever
+
+        entries = [{"id": "a"}, {"id": "b"}, {"id": "c"}]
+        rr = RerankedRetriever(_FakeBase(entries), _FakeReranker(available=True, order=[2, 0, 1]))
+        assert [e["id"] for e in rr.retrieve("query", top_k=2)] == ["c", "a"]
+
+    def test_has_data_delegates(self):
+        from vulnclaw.kb.retriever import RerankedRetriever
+
+        assert RerankedRetriever(_FakeBase([]), _FakeReranker()).has_data() is False
+        assert RerankedRetriever(_FakeBase([{"id": "a"}]), _FakeReranker()).has_data() is True
+
+
+# ── KnowledgeRetriever rerank opt-in ─────────────────────────────────
+
+
+class _UnavailableRerankerClass:
+    def __init__(self, *args, **kwargs):
+        self.available = False
+
+
+class TestKnowledgeRetrieverRerank:
+    def test_rerank_opt_in_degrades_when_unavailable(self, tmp_path, monkeypatch):
+        import vulnclaw.kb.retriever as retriever_mod
+        from vulnclaw.kb.retriever import KeywordRetriever, KnowledgeRetriever
+        from vulnclaw.kb.store import KnowledgeStore
+
+        monkeypatch.setattr(retriever_mod, "CHROMADB_AVAILABLE", False)
+        monkeypatch.setattr(retriever_mod, "CrossEncoderReranker", _UnavailableRerankerClass)
+
+        store = KnowledgeStore(store_dir=tmp_path)
+        store.add_entry(
+            "techniques",
+            "sqli-bypass",
+            {"title": "SQL 注入绕过技巧", "tags": ["sqli"]},
+        )
+
+        retriever = KnowledgeRetriever(store=store, rerank=True)
+        # Reranking was requested but is unavailable, so the backend degrades
+        # to the plain keyword retriever rather than a wrapped retriever.
+        assert isinstance(retriever._backend, KeywordRetriever)

--- a/vulnclaw/agent/experience_context.py
+++ b/vulnclaw/agent/experience_context.py
@@ -18,7 +18,7 @@ from datetime import datetime
 from typing import Any, Optional
 
 from vulnclaw.kb.experience import ExperienceStore
-from vulnclaw.kb.retriever import _tokenize
+from vulnclaw.kb.ranking import bigram_tokenize
 from vulnclaw.targets import parse_target
 
 _MAX_LESSONS = 5
@@ -150,12 +150,12 @@ def _rank_lessons(
 
 
 def _tfidf_similarity(query: str, documents: list[str]) -> list[float]:
-    """Use the KB keyword retriever's TF-IDF weighting model for ranking."""
-    query_counts = Counter(_tokenize(query))
+    """Rank documents by TF-IDF cosine similarity over Chinese-aware tokens."""
+    query_counts = Counter(bigram_tokenize(query))
     if not query_counts or not documents:
         return [0.0] * len(documents)
 
-    document_counts = [Counter(_tokenize(document)) for document in documents]
+    document_counts = [Counter(bigram_tokenize(document)) for document in documents]
     document_frequency: Counter[str] = Counter()
     for counts in document_counts:
         document_frequency.update(counts.keys())
@@ -214,7 +214,7 @@ def _as_items(value: Any) -> list[Any]:
 def _terms(value: Any) -> set[str]:
     if isinstance(value, Mapping):
         return {term for nested in value.values() for term in _terms(nested)}
-    return set(_tokenize(str(value)))
+    return set(bigram_tokenize(str(value)))
 
 
 def _single_line(value: Any) -> str:

--- a/vulnclaw/kb/ranking.py
+++ b/vulnclaw/kb/ranking.py
@@ -1,0 +1,154 @@
+"""Chinese-aware sparse ranking + optional cross-encoder reranking for the KB.
+
+This module holds the retrieval primitives used by ``KeywordRetriever``:
+
+- :func:`bigram_tokenize` — a tokenizer that keeps Latin alphanumeric runs as
+  whole tokens while splitting CJK into overlapping character bigrams, so the
+  predominantly-Chinese KB corpus is searchable without a segmentation
+  dictionary or any new required dependency.
+- :class:`BM25` — a small dependency-free Okapi BM25 scorer replacing the weak
+  TF-IDF overlap that previously failed to rank Chinese entries.
+- :class:`CrossEncoderReranker` — an optional cross-encoder precision stage,
+  imported lazily so the core path stays free of heavy dependencies.
+
+The public surface is deliberately minimal and independent of the KB store, so
+it can later be reused by the cold-memory and evidence search paths.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+from collections import Counter
+
+# A maximal run of either Latin letters/digits or CJK Unified Ideographs.
+# Latin runs are kept whole; CJK runs are split into overlapping bigrams.
+_RUN_RE = re.compile(r"[a-z0-9]+|[一-鿿]+")
+
+
+def bigram_tokenize(text: str) -> list[str]:
+    """Split ``text`` into Latin word tokens and CJK character bigrams.
+
+    Latin alphanumeric runs are lowercased and emitted as single tokens
+    (e.g. ``"SQL"`` -> ``"sql"``). CJK runs are emitted as overlapping
+    character bigrams (e.g. ``"注入绕过"`` -> ``"注入"``, ``"入绕"``, ``"绕过"``),
+    and a single isolated CJK character is emitted on its own. All other
+    characters act as token separators.
+
+    This keeps existing English-keyword behavior intact while making Chinese
+    content retrievable.
+    """
+    tokens: list[str] = []
+    for match in _RUN_RE.finditer(text.lower()):
+        run = match.group()
+        if run.isascii() or len(run) == 1:
+            tokens.append(run)
+        else:
+            tokens.extend(run[i : i + 2] for i in range(len(run) - 1))
+    return tokens
+
+
+class BM25:
+    """Dependency-free Okapi BM25 over a small in-memory document set.
+
+    Parameters ``k1`` and ``b`` control term-frequency saturation and
+    document-length normalization respectively. Documents are tokenized with
+    :func:`bigram_tokenize`, so both Latin and CJK content are scored.
+    """
+
+    def __init__(self, docs: list[str], *, k1: float = 1.5, b: float = 0.75) -> None:
+        self.k1 = float(k1)
+        self.b = float(b)
+        tokenized = [bigram_tokenize(doc) for doc in docs]
+        self._doc_counts = [Counter(tokens) for tokens in tokenized]
+        self._doc_len = [len(tokens) for tokens in tokenized]
+        count = len(tokenized)
+        self._avg_len = (sum(self._doc_len) / count) if count else 0.0
+
+        document_frequency: Counter[str] = Counter()
+        for doc_counts in self._doc_counts:
+            document_frequency.update(doc_counts.keys())
+        self._idf: dict[str, float] = {
+            token: math.log((count - freq + 0.5) / (freq + 0.5) + 1.0)
+            for token, freq in document_frequency.items()
+        }
+        self._norm = [
+            (1.0 - self.b + self.b * (length / self._avg_len)) if self._avg_len > 0 else 1.0
+            for length in self._doc_len
+        ]
+
+    def search(self, query: str, top_k: int) -> list[tuple[int, float]]:
+        """Return ``(doc_index, score)`` pairs ranked descending by BM25.
+
+        Only documents with a positive score are returned, at most ``top_k``
+        items. An empty query yields an empty list.
+        """
+        if not query or not self._doc_counts:
+            return []
+        query_counts = Counter(bigram_tokenize(query))
+        if not query_counts:
+            return []
+
+        scored: list[tuple[int, float]] = []
+        for index, doc_counts in enumerate(self._doc_counts):
+            score = 0.0
+            norm = self._norm[index]
+            for token, query_tf in query_counts.items():
+                doc_tf = doc_counts.get(token, 0)
+                if doc_tf <= 0:
+                    continue
+                idf = self._idf.get(token, 0.0)
+                if idf <= 0.0:
+                    continue
+                tf = doc_tf * (self.k1 + 1.0) / (doc_tf + self.k1 * norm)
+                score += idf * tf * float(query_tf)
+            if score > 0.0:
+                scored.append((index, score))
+
+        scored.sort(key=lambda pair: pair[1], reverse=True)
+        return scored[: max(0, int(top_k))]
+
+
+class CrossEncoderReranker:
+    """Optional cross-encoder precision stage over candidate documents.
+
+    A bi-encoder/BM25 pass recalls a broad candidate set; this reranks it with
+    a cross-encoder for finer ordering. The model is imported and loaded lazily
+    so importing this module never pulls in ``sentence-transformers`` unless a
+    reranker is actually constructed. When the dependency or model is missing,
+    :attr:`available` is ``False`` and callers should fall back to the base
+    retriever unchanged.
+    """
+
+    def __init__(self, model_name: str = "BAAI/bge-reranker-base") -> None:
+        self.model_name = model_name
+        self._model = None
+        try:
+            from sentence_transformers import CrossEncoder
+
+            self._model = CrossEncoder(model_name)
+        except Exception:
+            # Missing dependency or model download/load failure: leave the
+            # reranker unavailable so the caller degrades to the base retriever.
+            self._model = None
+
+    @property
+    def available(self) -> bool:
+        """Whether a usable cross-encoder was loaded successfully."""
+        return self._model is not None
+
+    def rerank(self, query: str, texts: list[str], top_k: int) -> list[int]:
+        """Return the indices of ``texts`` ordered by relevance to ``query``.
+
+        Returns at most ``top_k`` indices. ``texts`` must be non-empty.
+        """
+        if not self._model or not texts:
+            return []
+        pairs = [(query, text) for text in texts]
+        raw_scores = self._model.predict(pairs)
+        if isinstance(raw_scores, (int, float)):
+            scores = [float(raw_scores)]
+        else:
+            scores = [float(score) for score in raw_scores]
+        order = sorted(range(len(texts)), key=lambda index: scores[index], reverse=True)
+        return order[: max(0, int(top_k))]

--- a/vulnclaw/kb/retriever.py
+++ b/vulnclaw/kb/retriever.py
@@ -5,8 +5,9 @@ Retrieval degrades gracefully across three backends:
 - ``chromadb_active``   : semantic vector search (requires the optional
                           ``chromadb`` dependency, installed via
                           ``pip install vulnclaw[kb]``).
-- ``keyword_fallback``  : pure-Python keyword + TF-IDF scoring over the KB
-                          JSON corpus. No external dependency.
+- ``keyword_fallback``  : pure-Python Chinese-aware BM25 scoring over the KB
+                          JSON corpus, optionally reranked by a cross-encoder.
+                          No external dependency required.
 - ``disabled``          : no KB data is available at all.
 
 The public method surface (``get_cve``, ``search_by_service``,
@@ -17,12 +18,10 @@ active, so callers never need to branch on the backend.
 from __future__ import annotations
 
 import logging
-import math
-import re
-from collections import Counter
 from enum import Enum
 from typing import Any, Optional
 
+from vulnclaw.kb.ranking import BM25, CrossEncoderReranker
 from vulnclaw.kb.store import KnowledgeStore
 
 logger = logging.getLogger(__name__)
@@ -48,14 +47,6 @@ class RetrieverStatus(str, Enum):
     DISABLED = "disabled"
 
 
-_TOKEN_RE = re.compile(r"[a-z0-9]+")
-
-
-def _tokenize(text: str) -> list[str]:
-    """Split text into lowercase alphanumeric tokens."""
-    return _TOKEN_RE.findall(text.lower())
-
-
 def _entry_text(entry: dict[str, Any]) -> str:
     """Flatten the searchable text of a KB entry into a single string."""
     parts: list[str] = []
@@ -78,33 +69,16 @@ def _entry_text(entry: dict[str, Any]) -> str:
 class KeywordRetriever:
     """Pure-Python keyword retriever used when ChromaDB is unavailable.
 
-    Loads every KB entry into memory once, builds a small TF-IDF index, and
-    ranks documents against a query using cosine-like overlap scoring. No
-    vector database or external dependency is required.
+    Loads every KB entry into memory once and ranks documents against a query
+    with Okapi BM25 over Chinese-aware character-bigram tokens, so the
+    predominantly-Chinese KB corpus is searchable without a segmentation
+    dictionary or any external dependency.
     """
 
     def __init__(self, store: KnowledgeStore) -> None:
         self.store = store
-        self._docs: list[dict[str, Any]] = []
-        self._doc_tokens: list[Counter[str]] = []
-        self._idf: dict[str, float] = {}
-        self._build()
-
-    def _build(self) -> None:
-        """Load entries and compute IDF weights."""
-        self._docs = self.store.iter_all_entries()
-        self._doc_tokens = []
-        df: Counter[str] = Counter()
-        for entry in self._docs:
-            tokens = Counter(_tokenize(_entry_text(entry)))
-            self._doc_tokens.append(tokens)
-            for token in tokens:
-                df[token] += 1
-
-        n = max(len(self._docs), 1)
-        self._idf = {
-            token: math.log((n + 1) / (count + 1)) + 1.0 for token, count in df.items()
-        }
+        self._docs: list[dict[str, Any]] = self.store.iter_all_entries()
+        self._bm25: BM25 = BM25([_entry_text(entry) for entry in self._docs])
 
     def has_data(self) -> bool:
         """Return True when at least one document is indexed."""
@@ -112,24 +86,34 @@ class KeywordRetriever:
 
     def retrieve(self, query: str, top_k: int = 5) -> list[dict[str, Any]]:
         """Return the top-k entries most relevant to the query."""
-        query_tokens = _tokenize(query)
-        if not query_tokens or not self._docs:
-            return []
+        return [self._docs[index] for index, _score in self._bm25.search(query, top_k)]
 
-        q_counts = Counter(query_tokens)
-        scored: list[tuple[float, dict[str, Any]]] = []
-        for entry, tokens in zip(self._docs, self._doc_tokens):
-            score = 0.0
-            for token, q_tf in q_counts.items():
-                d_tf = tokens.get(token, 0)
-                if d_tf:
-                    weight = self._idf.get(token, 1.0)
-                    score += q_tf * d_tf * weight * weight
-            if score > 0:
-                scored.append((score, entry))
 
-        scored.sort(key=lambda pair: pair[0], reverse=True)
-        return [entry for _, entry in scored[:top_k]]
+class RerankedRetriever:
+    """Two-stage retriever: broad recall, then precise cross-encoder reranking.
+
+    Wraps a base retriever (e.g. :class:`KeywordRetriever`) that recalls more
+    candidates than needed, then reorders the top candidates with a
+    cross-encoder for finer ranking. When the reranker is unavailable or there
+    are too few candidates to reorder, the base ranking is returned unchanged.
+    """
+
+    def __init__(self, base: Any, reranker: CrossEncoderReranker, *, recall_k: int = 20) -> None:
+        self._base = base
+        self._reranker = reranker
+        self._recall_k = recall_k
+
+    def has_data(self) -> bool:
+        return self._base.has_data()
+
+    def retrieve(self, query: str, top_k: int = 5) -> list[dict[str, Any]]:
+        """Recall broadly, rerank, and return the top-k entries."""
+        candidates = self._base.retrieve(query, top_k=max(self._recall_k, top_k))
+        if len(candidates) <= top_k or not self._reranker.available:
+            return candidates[:top_k]
+        texts = [_entry_text(entry) for entry in candidates]
+        order = self._reranker.rerank(query, texts, top_k)
+        return [candidates[index] for index in order]
 
 
 class _ChromaRetriever:
@@ -190,8 +174,9 @@ class KnowledgeRetriever:
     its choice via :meth:`get_status`.
     """
 
-    def __init__(self, store: Optional[KnowledgeStore] = None) -> None:
+    def __init__(self, store: Optional[KnowledgeStore] = None, *, rerank: bool = False) -> None:
         self.store = store or KnowledgeStore()
+        self._rerank_enabled = rerank
         self._status: RetrieverStatus = RetrieverStatus.DISABLED
         self._status_detail: str = ""
         self._backend: Any = None
@@ -226,6 +211,8 @@ class KnowledgeRetriever:
             return
 
         self._backend = keyword
+        if self._rerank_enabled:
+            self._backend = self._wrap_reranker(keyword)
         if keyword.has_data():
             self._status = RetrieverStatus.KEYWORD_FALLBACK
             if not CHROMADB_AVAILABLE:
@@ -238,6 +225,20 @@ class KnowledgeRetriever:
         else:
             self._status = RetrieverStatus.DISABLED
             self._status_detail = _("kb.status.empty")
+
+    def _wrap_reranker(self, base: Any) -> Any:
+        """Wrap ``base`` with a cross-encoder reranking stage when possible.
+
+        The cross-encoder is loaded lazily and only when reranking was
+        explicitly enabled; if the dependency or model is missing, ``base`` is
+        returned unchanged so the retriever degrades to base ranking instead of
+        failing.
+        """
+        reranker = CrossEncoderReranker()
+        if not reranker.available:
+            logger.info("Cross-encoder reranker unavailable; keeping base ranking")
+            return base
+        return RerankedRetriever(base, reranker)
 
     # ── Status reporting ─────────────────────────────────────────────
 


### PR DESCRIPTION
Fixes #251

  ## 问题

  关键词兜底检索器（ChromaDB 未安装时启用）用 `[a-z0-9]+`分词，会把所有中文字符全部丢弃。由于内置知识库语料以中文为主（「SQL 注入绕过技巧」「PHP命令执行绕过技巧」……），任何中文查询、或仅靠中文词才能区分的条目，在这个后端下都无法被检索到：`_tokenize("SQL注入绕过")` 返回 `["sql"]`。未安装可选依赖 ChromaDB 的用户，中文查询会拿到空结果；即便英文查询也无法按条目的中文内容排序。而代码库其他位置（`vulnclaw/config/finding_similarity.py` 用的是 `[a-z0-9一-鿿]+`）早已做到 CJK感知，说明此处是疏漏而非有意为之。

  ## 解决方案

  用零依赖的 Okapi BM25 替换原来脆弱的 TF-IDF 重叠打分，底层换用中文感知分词器：

  - `bigram_tokenize` — 拉丁字母数字串整体保留为词元（维持原有英文行为），CJK连续片段拆成重叠的字符二元组（bigram）。零依赖、无需分词词典，对短小的安全文本稳定可靠。
  - `BM25` — Okapi 打分，带词频饱和（k1=1.5）和文档长度归一（b=0.75）。
  - `CrossEncoderReranker` + `RerankedRetriever` — 可选的精排阶段（BM25 召回 → cross-encoder重排），懒加载，核心路径保持零依赖。

  为什么这样做：

  - 不新增必需依赖（手写 BM25 与现有手写 TF-IDF 风格一致）。
  - 保持公开接口不变（`KeywordRetriever` 类名、`retrieve(query,top_k)`、`RetrieverStatus.KEYWORD_FALLBACK`），已有调用方和测试不受影响。
  - 重排序器默认关闭、按需开启（`KnowledgeRetriever(..., rerank=True)`），agent 主循环永远不会被模型下载阻塞。

  ## 改动

  - 新增 `vulnclaw/kb/ranking.py`：`bigram_tokenize`、`BM25`、`CrossEncoderReranker`。
  - 重构 `vulnclaw/kb/retriever.py`：`KeywordRetriever` 改用 BM25 排序；新增 `RerankedRetriever`；给
  `KnowledgeRetriever` 增加 `rerank` 参数与 `_wrap_reranker()`；移除旧的 `_tokenize`/`_TOKEN_RE` 以及不再使用的
  `math`/`re`/`Counter` 导入。
  - 将 `vulnclaw/agent/experience_context.py` 从已删除的 `retriever._tokenize` 迁移到 `ranking.bigram_tokenize`（顺带获得中文感知能力）
  - 新增 `tests/kb/test_ranking.py`，并在 `tests/kb/test_kb_fallback.py` 中新增一条中文查询回归测试。
  - 在 `pyproject.toml` 中声明新的 `[rerank]` 可选依赖（`sentence-transformers>=2.2.0`）。
  - 更新 `README.md` 与 `README_EN.md` 中知识库模块表对应行。

  ## 测试

  - `pytest tests/kb/test_kb.py tests/kb/test_kb_fallback.py tests/kb/test_ranking.py` → **61 passed, 1 skipped**（其中 16 条为本 PR 新增；1 条跳过为既有的 Windows 专属 chmod 测试）。
  - 新增测试覆盖：分词器（中文 bigram、拉丁串、单字符、空串、标点）、BM25（中英文排序、空/无命中、`top_k` 截断）、`RerankedRetriever`（降级 + 重排 + `has_data` 委托）、`KnowledgeRetriever(rerank=True)` 降级，以及一条端到端回归断言 `kw.retrieve("注入绕过")` 能命中中文条目。
  - `ruff check vulnclaw/kb tests/kb` → 通过。

  ## 给Reviewer的说明

  - 重排序器刻意做成默认关闭、按需开启：构造 cross-encoder 会触发（可能很大的）模型下载，绝不能出现在 agent的默认检索路径上。仅当传入 `KnowledgeRetriever(..., rerank=True)` 时才加载。
  - 重排序器只包裹关键词后端，不包裹 ChromaDB（后者已做语义检索），范围严格限定在出错的关键词路径上。
  - 旧的 `_tokenize`/`_TOKEN_RE` 是模块私有、无外部引用，故直接删除而非与新分词器并存。
  - 仅覆盖 KB 检索器；冷记忆（`memory_search`）与证据搜索里同样 CJK 盲区的检索留作后续，可复用 `ranking.py`。
  - `tests/kb/test_kb_fallback.py` 保留了一处既有的非 `ruff-format`
  签名（`test_assembled_system_prompt_has_no_chinese_kb_text_under_en`），为减小 diff 未做改动。