### PR TITLE
feat(tui): restore /run /recon /scan /exploit /persistent /codescan s…

### DIFF
--- a/tests/tui/app.rs
+++ b/tests/tui/app.rs
@@ -80,9 +80,11 @@ fn composer_suggests_and_completes_slash_commands() {
 }
 
 #[test]
-fn task_dispatch_uses_backend_advertised_commands() {
+fn task_dispatch_uses_frontend_known_task_verbs() {
     let (sender, _) = mpsc::channel();
     let mut app = App::new_disconnected(sender);
+    app.mode = ExecutionMode::Agent;
+    app.backend_ready = true;
     app.backend_commands = vec!["recon".into()];
     app.insert_text("/recon https://lab.example");
     app.submit();
@@ -92,20 +94,26 @@ fn task_dispatch_uses_backend_advertised_commands() {
         Some("/recon https://lab.example")
     );
 
+    // /run is a known task verb even if the backend has not advertised it,
+    // so it is accepted and armed (execution is still gated on backend_ready).
     app.dismiss_task();
+    app.backend_ready = true;
+    app.backend_commands = Vec::new();
     app.insert_text("/run https://lab.example");
     app.submit();
-    assert!(app.pending_task.is_none());
+    assert!(app.pending_task.is_some());
     assert!(app
         .transcript
         .iter()
-        .any(|item| item.text.contains("Unknown command: /run")));
+        .any(|item| item.text.contains("armed for")));
 }
 
 #[test]
-fn codescan_dispatches_when_advertised_by_backend() {
+fn codescan_dispatches_as_known_task_verb() {
     let (sender, _) = mpsc::channel();
     let mut app = App::new_disconnected(sender);
+    app.mode = ExecutionMode::Agent;
+    app.backend_ready = true;
     app.backend_commands = vec!["codescan".into()];
     app.insert_text("/codescan demo/unsafe-ai-sample.ts");
     app.submit();
@@ -115,16 +123,14 @@ fn codescan_dispatches_when_advertised_by_backend() {
         Some("/codescan demo/unsafe-ai-sample.ts")
     );
 
-    // Not advertised -> rejected as unknown.
+    // /codescan is part of the frontend's canonical task verbs, so it is still
+    // armed when the backend has not advertised it yet.
     app.dismiss_task();
-    app.insert_text("/codescan src/main.rs");
+    app.backend_ready = true;
     app.backend_commands = Vec::new();
+    app.insert_text("/codescan src/main.rs");
     app.submit();
-    assert!(app.pending_task.is_none());
-    assert!(app
-        .transcript
-        .iter()
-        .any(|item| item.text.contains("Unknown command: /codescan")));
+    assert!(app.pending_task.is_some());
 }
 
 #[test]
@@ -361,6 +367,7 @@ fn agent_mode_arms_a_task_and_waits_for_confirmation() {
     let mut app = App::new_disconnected(sender);
     app.mode = ExecutionMode::Agent;
     app.permission = PermissionMode::FullAccess;
+    app.backend_ready = true;
     app.backend_commands = vec!["run".into()];
 
     app.insert_text("/run https://lab.example");
@@ -383,6 +390,7 @@ fn task_requires_a_target() {
     let (sender, _) = mpsc::channel();
     let mut app = App::new_disconnected(sender);
     app.mode = ExecutionMode::Agent;
+    app.backend_ready = true;
     app.backend_commands = vec!["run".into()];
 
     app.insert_text("/run");

--- a/tui/src/app.rs
+++ b/tui/src/app.rs
@@ -208,12 +208,24 @@ pub struct SlashCommand {
     pub description: &'static str,
 }
 
+/// Slash commands rendered locally in the TUI composer palette. The first
+/// five are presentation-layer helpers; the remainder mirror the task verbs
+/// advertised by the Python backend via `capabilities.commands`. Keeping them
+/// here ensures the palette is never empty (or misleadingly tiny) while the
+/// backend is still initializing, and gives users a discoverable path to the
+/// core pentest workflows even if the capability handshake is delayed.
 const LOCAL_SLASH_COMMANDS: &[(&str, &str)] = &[
     ("/scope ", "update session scope defaults"),
     ("/report", "show report export guidance"),
     ("/config", "show configuration guidance"),
     ("/clear", "clear the transcript"),
     ("/help", "list available commands"),
+    ("/run ", "run a task through the Python backend"),
+    ("/recon ", "run a task through the Python backend"),
+    ("/scan ", "run a task through the Python backend"),
+    ("/exploit ", "run a task through the Python backend"),
+    ("/persistent ", "run a task through the Python backend"),
+    ("/codescan ", "run a task through the Python backend"),
 ];
 
 const MAX_COMMAND_HISTORY: usize = 50;
@@ -445,7 +457,7 @@ impl App {
         } else if let Some((verb, arguments)) = split_slash_command(&command) {
             if verb == "scope" {
                 self.request_scope_control(arguments);
-            } else if self.backend_commands.iter().any(|item| item == verb) {
+            } else if is_task_verb(verb) {
                 self.request_task(verb, arguments);
             } else {
                 self.error(format!("Unknown command: {command}"));
@@ -1480,6 +1492,19 @@ fn split_slash_command(command: &str) -> Option<(&str, &str)> {
     let split_at = raw.find(char::is_whitespace).unwrap_or(raw.len());
     let (verb, remainder) = raw.split_at(split_at);
     (!verb.is_empty()).then_some((verb, remainder.trim_start()))
+}
+
+/// Check whether a slash verb maps to a known task command.
+///
+/// This mirrors `TaskCommand` in `vulnclaw/task_service.py`. Keeping the set
+/// explicit on the frontend lets the TUI offer meaningful completions even
+/// before the backend capability handshake finishes, while still routing the
+/// command through the same protocol path once executed.
+fn is_task_verb(verb: &str) -> bool {
+    matches!(
+        verb,
+        "run" | "recon" | "scan" | "exploit" | "persistent" | "codescan"
+    )
 }
 
 /// Adapt a presentation-layer slash command into the structured task DTO sent


### PR DESCRIPTION
…lash commands in ratatui

- Expand LOCAL_SLASH_COMMANDS with canonical task verbs so they remain discoverable before backend capability handshake completes.

- Add is_task_verb() mirroring vulnclaw/task_service.py TaskCommand.

- Route task slash commands through request_task regardless of backend advertisement; actual execution is still gated by backend_ready in start_task.

- Update tui tests to reflect frontend-known task verb behavior.

- cargo test --test tui: 63 passed