### PR TITLE
fix(i18n): add missing cli.host_no_set English translation

### DIFF
--- a/tests/i18n/test_catalog_parity.py
+++ b/tests/i18n/test_catalog_parity.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def _catalog(language: str) -> dict[str, str]:
+    path = Path(__file__).resolve().parents[2] / "vulnclaw" / "i18n" / f"{language}.json"
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_translation_catalogs_have_matching_keys_outside_skill_namespace():
+    """Every non-skill key must exist in both en.json and zh.json.
+
+    ``skill.<name>.description`` overrides are intentionally English-only
+    (frontmatter descriptions are authored in Chinese and used as fallback),
+    so they are excluded here.
+    """
+    english = {k for k in _catalog("en") if not k.startswith("skill.")}
+    chinese = {k for k in _catalog("zh") if not k.startswith("skill.")}
+
+    assert english == chinese

--- a/vulnclaw/i18n/en.json
+++ b/vulnclaw/i18n/en.json
@@ -25,6 +25,7 @@
   "cli.language_set_to": "Language set to",
   "cli.resuming_auto_pentest": "Resuming auto pentest",
   "cli.compressed_earlier_context": "[green]Compressed earlier context[/green], keeping recent messages; summary length {var_001} characters.",
+  "cli.host_no_set": "[!] Set a target first with [bold]target <host>[/] or run [bold]persistent <host>[/].",
   "cli.target_within_range_and_explicitly_authorized": "This target is in scope and explicitly authorized.",
   "report.rec.uncategorized": "Uncategorized",
   "report.rec.fix_priority": "Prioritize fixing {vt} risk: {title}",


### PR DESCRIPTION
Fixes #256

## What
- Add the missing `cli.host_no_set` entry to `vulnclaw/i18n/en.json`.
- Add a catalog parity test (non-`skill.*` keys must exist in both en.json and zh.json). The existing i18n test only covers the `agent.*` namespace, which is how this key slipped through.

## Why
`I18nLoader.t()` returns the raw key when a translation is missing, so English users running `persistent` in the REPL without a target see the literal string `cli.host_no_set` instead of the hint.

## How verified
- `I18nLoader("en").t("cli.host_no_set")` renders the full English hint; before the fix it returned the raw key.
- The new parity test fails on `dev` and passes with this change.
- `ruff check` clean.