### PR TITLE
docs: remove README references to nonexistent docs/keyless-auth.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ vulnclaw config set llm.model your-model-name
 # 2. 设置 API Key
 vulnclaw config set llm.api_key sk-your-key-here
 #    — 或改用 ChatGPT 订阅登录（无需 API Key）：
-#      vulnclaw login   （浏览器登录；详见 docs/keyless-auth.md，注意 ToS 风险）
+#      vulnclaw login   （浏览器登录；注意 ToS 风险）
 
 # 3. 默认：打开原 CLI / REPL
 vulnclaw

--- a/README_EN.md
+++ b/README_EN.md
@@ -144,7 +144,7 @@ vulnclaw config set llm.model your-model-name
 # 2. Set API Key
 vulnclaw config set llm.api_key sk-your-key-here
 #    — or sign in with ChatGPT subscription (no API key needed):
-#      vulnclaw login   (browser sign-in; see docs/keyless-auth.md, note ToS caveat)
+#      vulnclaw login   (browser sign-in; note ToS caveat)
 
 # 3. Default: open the original CLI / REPL
 vulnclaw


### PR DESCRIPTION
### 变更内容

README.md 与 README_EN.md 中引用了 `docs/keyless-auth.md`，但该文件在仓库任何分支的完整 git 历史中都不存在。本 PR 删除这两处死引用，行内的 ToS 风险提示保留不变。

- `README.md:142`、`README_EN.md:147`：仅删除"详见 docs/keyless-auth.md"片段，各 1 行
- `vulnclaw login` 命令本身真实存在，不受影响

Fixes #258

### 验证

- `git log --all -- docs/keyless-auth.md` 确认该文件从未在任何分支存在
- 修改后 `git grep keyless-auth` 全仓库无残留引用
- diff 仅 2 个文件各 1 行，无其他改动
