### PR TITLE
fix(cli): paste and scroll classic /config panel

### DIFF
--- a/scripts/verify_execution_boundary.py
+++ b/scripts/verify_execution_boundary.py
@@ -99,7 +99,13 @@ ALLOWED_SPAWN_SITES: dict[str, str] = {
     "vulnclaw/cli/tui.py:1734:subprocess.run": (
         "operator control plane: fixed version diagnostic"
     ),
-    "vulnclaw/cli/main.py:2581:subprocess.run": (
+    "vulnclaw/cli/tui.py:2623:subprocess.run": (
+        "operator control plane: Windows Get-Clipboard via powershell for /config paste"
+    ),
+    "vulnclaw/cli/tui.py:2662:subprocess.run": (
+        "operator control plane: Unix pbpaste/wl-paste/xclip/xsel for /config paste"
+    ),
+    "vulnclaw/cli/main.py:2582:subprocess.run": (
         "operator control plane: fixed Node.js version diagnostic"
     ),
     # First-run setup wizard (merged from dev): operator-driven fixed argv

--- a/tests/cli/test_config_panel.py
+++ b/tests/cli/test_config_panel.py
@@ -105,6 +105,44 @@ def test_text_edit_commits_on_enter(model):
     assert model.editing is False
 
 
+def test_paste_text_appends_into_active_editor_and_strips_newlines(model):
+    """Bracketed paste / clipboard paste must land in edit_text, not be dropped."""
+    _focus(model, "llm.api_key")
+    model.activate()
+    model.set_edit_text("sk-")
+
+    model.paste_text("pre\r\nfix\nkey\r")
+
+    assert model.edit_text == "sk-prefixkey"
+    assert model.row_error == ""
+
+
+def test_paste_text_is_a_no_op_when_not_editing(model):
+    _focus(model, "llm.api_key")
+
+    model.paste_text("sk-should-not-land")
+
+    assert model.editing is False
+    assert model.edit_text == ""
+
+
+def test_apply_clipboard_routes_text_and_reports_empty_or_unavailable(model):
+    _focus(model, "llm.api_key")
+    model.activate()
+
+    model.apply_clipboard("sk-from-clipboard")
+    assert model.edit_text == "sk-from-clipboard"
+    assert model.row_error == ""
+
+    model.apply_clipboard("")
+    assert model.edit_text == "sk-from-clipboard"
+    assert model.row_error == "Nothing to paste: clipboard is empty"
+
+    model.apply_clipboard(None)
+    assert model.edit_text == "sk-from-clipboard"
+    assert model.row_error == "Paste failed: clipboard unavailable"
+
+
 def test_text_edit_cancel_restores_previous_value(model):
     model.draft.llm.reasoning_effort = "medium"
     _focus(model, "llm.reasoning_effort")
@@ -253,6 +291,87 @@ def test_dropdown_selection_does_not_run_off_either_end(model):
 
     model.select_option(5)
     assert model.dropdown_index == 1
+
+
+def test_long_dropdown_only_exposes_a_window_around_the_selection(model):
+    """OpenRouter-sized model lists must not dump every option into the UI."""
+    model.models = [f"provider/model-{i:03d}" for i in range(80)]
+    _focus(model, "llm.model")
+    model.activate()
+    model.set_viewport_height(10)
+
+    _, dropdown_rows = model._table_row_budget()
+    visible = model.visible_dropdown_options()
+    assert len(visible) <= dropdown_rows
+    assert visible[0][0] == 0  # (absolute_index, name)
+    assert all(visible[i][0] == i for i in range(len(visible)))
+
+    # Move past the first window; the slice must follow the selection.
+    model.select_option(25)
+    visible = model.visible_dropdown_options()
+    indices = [index for index, _ in visible]
+    assert model.dropdown_index in indices
+    assert len(visible) <= dropdown_rows
+    assert indices[0] > 0
+
+
+def test_dropdown_table_rows_fit_within_viewport(model):
+    model.models = [f"m-{i}" for i in range(40)]
+    _focus(model, "llm.model")
+    model.activate()
+    model.set_viewport_height(8)
+
+    panel_rows, dropdown_rows = model._table_row_budget()
+    assert panel_rows + dropdown_rows <= model.viewport_height
+    assert len(model.visible_rows()) <= panel_rows
+    assert len(model.visible_dropdown_options()) <= dropdown_rows
+
+
+def test_dropdown_window_scrolls_up_when_selection_moves_above_it(model):
+    model.models = [f"m-{i}" for i in range(40)]
+    _focus(model, "llm.model")
+    model.activate()
+    model.set_viewport_height(5)
+    model.select_option(20)
+    assert model.visible_dropdown_options()[0][0] > 0
+
+    for _ in range(30):
+        model.select_option(-1)
+
+    assert model.dropdown_index == 0
+    assert model.visible_dropdown_options()[0][0] == 0
+
+
+def test_render_omits_dropdown_options_outside_the_window():
+    import io
+
+    from rich.console import Console
+
+    from vulnclaw.cli.config_panel_render import render_panel
+
+    model = ConfigPanelModel(VulnClawConfig())
+    model.models = [f"provider/model-{i:03d}" for i in range(50)]
+    _focus(model, "llm.model")
+    model.activate()
+    model.set_viewport_height(6)
+
+    buf = io.StringIO()
+    Console(file=buf, force_terminal=True, width=120).print(render_panel(model))
+    output = buf.getvalue()
+
+    _, dropdown_rows = model._table_row_budget()
+    # Labels may be ellipsis-truncated; count option rows via the stable prefix.
+    assert output.count("model-") == dropdown_rows
+    assert "model-49" not in output
+
+
+def test_paste_into_list_field_preserves_item_separators(model):
+    _focus(model, "llm.api_keys")
+    model.activate()
+
+    model.paste_text("sk-one\nsk-two")
+
+    assert model.edit_text == "sk-one,sk-two"
 
 
 def test_changing_provider_applies_the_preset_and_bumps_the_generation(model):

--- a/tests/cli/test_config_panel_paste.py
+++ b/tests/cli/test_config_panel_paste.py
@@ -1,0 +1,56 @@
+"""Clipboard + paste wiring for the classic-REPL config panel."""
+
+from __future__ import annotations
+
+import tempfile
+from types import SimpleNamespace
+
+from vulnclaw.cli import tui as tui_mod
+
+
+def test_read_system_clipboard_windows_strips_bom_and_returns_text(monkeypatch, tmp_path):
+    monkeypatch.setattr(tui_mod.sys, "platform", "win32")
+    monkeypatch.setattr(tempfile, "gettempdir", lambda: str(tmp_path))
+
+    def fake_run(cmd, **kwargs):
+        path = tmp_path / f"vulnclaw-paste-{tui_mod.os.getpid()}.txt"
+        path.write_bytes(b"\xef\xbb\xbfsk-pasted-key")
+        return SimpleNamespace(returncode=0, stdout=b"", stderr=b"")
+
+    monkeypatch.setattr(tui_mod.subprocess, "run", fake_run)
+
+    assert tui_mod._read_system_clipboard() == "sk-pasted-key"
+    assert not (tmp_path / f"vulnclaw-paste-{tui_mod.os.getpid()}.txt").exists()
+
+
+def test_read_system_clipboard_windows_returns_none_on_failure(monkeypatch, tmp_path):
+    monkeypatch.setattr(tui_mod.sys, "platform", "win32")
+    monkeypatch.setattr(tempfile, "gettempdir", lambda: str(tmp_path))
+    monkeypatch.setattr(
+        tui_mod.subprocess,
+        "run",
+        lambda *a, **k: SimpleNamespace(returncode=1, stdout=b"", stderr=b"boom"),
+    )
+
+    assert tui_mod._read_system_clipboard() is None
+
+
+def test_read_system_clipboard_unix_uses_first_working_helper(monkeypatch):
+    monkeypatch.setattr(tui_mod.sys, "platform", "linux")
+    calls: list[tuple[str, ...]] = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(tuple(cmd))
+        if cmd[0] == "pbpaste":
+            raise FileNotFoundError("no pbpaste")
+        if cmd[0] == "wl-paste":
+            return SimpleNamespace(returncode=1, stdout=b"", stderr=b"")
+        if cmd[0] == "xclip":
+            return SimpleNamespace(returncode=0, stdout=b"from-xclip", stderr=b"")
+        return SimpleNamespace(returncode=1, stdout=b"", stderr=b"")
+
+    monkeypatch.setattr(tui_mod.subprocess, "run", fake_run)
+
+    assert tui_mod._read_system_clipboard() == "from-xclip"
+    assert calls[0][0] == "pbpaste"
+    assert any(c[0] == "xclip" for c in calls)

--- a/tests/cli/test_config_panel_render.py
+++ b/tests/cli/test_config_panel_render.py
@@ -62,6 +62,32 @@ def test_open_dropdown_lists_its_options():
     assert "html" in output
 
 
+def test_selected_dropdown_option_cursor_uses_orange_warning_color():
+    from vulnclaw.cli.tui import C_WARNING
+
+    model = ConfigPanelModel(VulnClawConfig())
+    model._expanded.add("session")
+    model._focus_key = "session.report_format"
+    model.activate()
+    model.select_option(1)
+
+    console = Console(
+        file=io.StringIO(),
+        record=True,
+        width=120,
+        height=40,
+        force_terminal=True,
+        color_system="truecolor",
+    )
+    from vulnclaw.i18n import init_i18n
+
+    init_i18n("en")
+    console.print(render_panel(model))
+    html = console.export_html(inline_styles=True)
+
+    assert C_WARNING.lstrip("#").lower() in html.lower()
+
+
 def test_expanded_llm_section_shows_the_idle_fetch_hint():
     model = ConfigPanelModel(VulnClawConfig())
     model.toggle_expand()  # focus starts on the llm group

--- a/tests/cli/test_format_llm_user_error.py
+++ b/tests/cli/test_format_llm_user_error.py
@@ -1,0 +1,26 @@
+"""Tests for LLM error formatting in the classic REPL."""
+
+from vulnclaw.cli._helpers import format_llm_user_error
+
+
+def test_format_llm_user_error_prefers_openrouter_metadata_raw():
+    class _E(Exception):
+        def __init__(self):
+            super().__init__("Error code: 429 - blob")
+            self.body = {
+                "message": "Provider returned error",
+                "code": 429,
+                "metadata": {
+                    "raw": "google/gemma-4-26b-a4b-it:free is temporarily rate-limited upstream.",
+                    "remedy_hint": "Retry shortly or switch models.",
+                },
+            }
+
+    msg = format_llm_user_error(_E())
+    assert "rate-limited upstream" in msg
+    assert "Retry shortly" in msg
+    assert "Provider returned error" not in msg
+
+
+def test_format_llm_user_error_falls_back_to_str():
+    assert format_llm_user_error(RuntimeError("boom")) == "boom"

--- a/vulnclaw/cli/_helpers.py
+++ b/vulnclaw/cli/_helpers.py
@@ -26,6 +26,29 @@ TUI_EVENT_TOKEN_ENV = "VULNCLAW_TUI_EVENT_TOKEN"
 TUI_EVENT_PREFIX = "__VULNCLAW_TUI_EVENT__:"
 
 
+def format_llm_user_error(exc: BaseException) -> str:
+    """Turn provider exceptions into a short message for the REPL.
+
+    OpenRouter wraps upstream rate limits as ``Provider returned error`` with the
+    useful text buried in ``body['metadata']['raw']`` — surface that instead of
+    dumping the whole Error code blob after ``Thinking...``.
+    """
+    body = getattr(exc, "body", None)
+    if isinstance(body, Mapping):
+        meta = body.get("metadata")
+        if isinstance(meta, Mapping):
+            raw = str(meta.get("raw") or "").strip()
+            hint = str(meta.get("remedy_hint") or "").strip()
+            if raw:
+                return f"{raw}" + (f" ({hint})" if hint else "")
+        message = str(body.get("message") or "").strip()
+        code = body.get("code")
+        if message:
+            return f"{code}: {message}" if code is not None else message
+    text = str(exc).strip()
+    return text or type(exc).__name__
+
+
 @dataclass(frozen=True)
 class SubagentTuiEvent:
     kind: str

--- a/vulnclaw/cli/config_panel.py
+++ b/vulnclaw/cli/config_panel.py
@@ -313,6 +313,7 @@ class ConfigPanelModel:
         self.row_error = ""
         self._dropdown: dict[str, Any] | None = None
         self.dropdown_index = 0
+        self._dropdown_scroll = 0
         self.generation = 0
         self.models: list[str] = []
         self.fetch_state = "idle"
@@ -458,10 +459,16 @@ class ConfigPanelModel:
             self._scroll_offset = 0
             return
         self.viewport_height = height
-        self._ensure_focus_in_view()
+        self._ensure_focus_in_view(self._panel_viewport_rows())
 
-    def _ensure_focus_in_view(self) -> None:
-        height = self.viewport_height
+    def _panel_viewport_rows(self) -> int | None:
+        if self.viewport_height is None:
+            return None
+        panel_rows, _ = self._table_row_budget()
+        return panel_rows
+
+    def _ensure_focus_in_view(self, height: int | None = None) -> None:
+        height = height if height is not None else self.viewport_height
         if height is None:
             return
         rows = self.rows()
@@ -477,24 +484,44 @@ class ConfigPanelModel:
         max_offset = max(0, n - height)
         self._scroll_offset = max(0, min(self._scroll_offset, max_offset))
 
+    def _table_row_budget(self) -> tuple[int, int]:
+        """Split ``viewport_height`` between panel rows and inline dropdown options.
+
+        Dropdown options render as extra table rows, so their height must be
+        reserved from the same budget as ``visible_rows()``.
+        """
+        height = self.viewport_height
+        options = self.dropdown_options
+        if height is None:
+            return (999999, len(options) if self.dropdown_open else 0)
+        if not self.dropdown_open or not options:
+            return (height, 0)
+        prefer_dropdown = min(len(options), max(3, height // 3))
+        panel_rows = height - prefer_dropdown
+        if panel_rows < 1:
+            panel_rows = 1
+            prefer_dropdown = min(len(options), height - 1)
+        return (panel_rows, max(1, prefer_dropdown))
+
     def visible_rows(self) -> list[Row]:
         """Rows to paint for the current viewport (full list when unbounded)."""
         rows = self.rows()
-        self._ensure_focus_in_view()
         height = self.viewport_height
         if height is None:
             return rows
-        return rows[self._scroll_offset : self._scroll_offset + height]
+        panel_rows, _ = self._table_row_budget()
+        self._ensure_focus_in_view(panel_rows)
+        return rows[self._scroll_offset : self._scroll_offset + panel_rows]
 
     def focus_next(self) -> None:
         rows = self.rows()
         self._focus_key = rows[min(self._focus_index() + 1, len(rows) - 1)].key
-        self._ensure_focus_in_view()
+        self._ensure_focus_in_view(self._panel_viewport_rows())
 
     def focus_prev(self) -> None:
         rows = self.rows()
         self._focus_key = rows[max(self._focus_index() - 1, 0)].key
-        self._ensure_focus_in_view()
+        self._ensure_focus_in_view(self._panel_viewport_rows())
 
     # -- expansion --------------------------------------------------------
 
@@ -506,25 +533,25 @@ class ConfigPanelModel:
             self._expanded.discard(row.key)
         else:
             self._expanded.add(row.key)
-        self._ensure_focus_in_view()
+        self._ensure_focus_in_view(self._panel_viewport_rows())
 
     def expand(self) -> None:
         row = self.focused
         if row.kind == "group":
             self._expanded.add(row.key)
-            self._ensure_focus_in_view()
+            self._ensure_focus_in_view(self._panel_viewport_rows())
 
     def collapse(self) -> None:
         row = self.focused
         if row.kind == "group":
             self._expanded.discard(row.key)
-            self._ensure_focus_in_view()
+            self._ensure_focus_in_view(self._panel_viewport_rows())
             return
         parent = self._parent_key(row)
         if parent is not None:
             self._expanded.discard(parent)
             self._focus_key = parent
-            self._ensure_focus_in_view()
+            self._ensure_focus_in_view(self._panel_viewport_rows())
 
     def _parent_key(self, row: Row) -> str | None:
         if row.key == "action.fetch_models":
@@ -611,6 +638,35 @@ class ConfigPanelModel:
         if self._edit is not None:
             self._edit["text"] = text
 
+    def paste_text(self, text: str) -> None:
+        """Append pasted text into the active editor.
+
+        Single-line fields drop CR/LF. List and env fields treat newlines as item
+        separators, matching ``split_csv_items`` / ``parse_env_items`` on commit.
+        No-op when not editing so accidental paste outside an editor is ignored.
+        """
+        if self._edit is None:
+            return
+        row = self._editing_row()
+        if row is not None and row.value_kind in (SECRET_LIST, LIST, ENV):
+            cleaned = text.replace("\r\n", "\n").replace("\r", "\n").replace("\n", ",")
+        else:
+            cleaned = "".join(ch for ch in text if ch not in "\r\n")
+        self._edit["text"] += cleaned
+        self.row_error = ""
+
+    def apply_clipboard(self, clipboard: str | None) -> None:
+        """Route a clipboard read into the editor (testable without a real clipboard)."""
+        if self._edit is None:
+            return
+        if clipboard is None:
+            self.row_error = "Paste failed: clipboard unavailable"
+            return
+        if clipboard == "":
+            self.row_error = "Nothing to paste: clipboard is empty"
+            return
+        self.paste_text(clipboard)
+
     def cancel_edit(self) -> None:
         self._edit = None
         self.row_error = ""
@@ -634,6 +690,8 @@ class ConfigPanelModel:
             self._dropdown = {"options": options}
             current = self.raw_value(row)
             self.dropdown_index = options.index(current) if current in options else 0
+            self._dropdown_scroll = 0
+            self._sync_dropdown_scroll()
             return
         self._edit = {"key": row.key, "text": self._edit_seed(row)}
 
@@ -711,15 +769,51 @@ class ConfigPanelModel:
     def dropdown_options(self) -> list[str]:
         return self._dropdown["options"] if self._dropdown else []
 
+    def _dropdown_window_height(self) -> int:
+        """How many option rows to paint. Unbounded when no panel viewport is set."""
+        options = self.dropdown_options
+        if not options:
+            return 0
+        if self.viewport_height is None:
+            return len(options)
+        _, dropdown_rows = self._table_row_budget()
+        return min(len(options), dropdown_rows)
+
+    def _sync_dropdown_scroll(self) -> None:
+        options = self.dropdown_options
+        if not options:
+            self._dropdown_scroll = 0
+            return
+        height = self._dropdown_window_height()
+        max_offset = max(0, len(options) - height)
+        if self.dropdown_index < self._dropdown_scroll:
+            self._dropdown_scroll = self.dropdown_index
+        elif self.dropdown_index >= self._dropdown_scroll + height:
+            self._dropdown_scroll = self.dropdown_index - height + 1
+        self._dropdown_scroll = max(0, min(self._dropdown_scroll, max_offset))
+
+    def visible_dropdown_options(self) -> list[tuple[int, str]]:
+        """Windowed (absolute_index, option) pairs so long model lists can scroll."""
+        options = self.dropdown_options
+        if not options:
+            return []
+        self._sync_dropdown_scroll()
+        height = self._dropdown_window_height()
+        start = self._dropdown_scroll
+        end = min(len(options), start + height)
+        return [(index, options[index]) for index in range(start, end)]
+
     def select_option(self, delta: int) -> None:
         if self._dropdown is None:
             return
         limit = len(self._dropdown["options"]) - 1
         self.dropdown_index = max(0, min(self.dropdown_index + delta, limit))
+        self._sync_dropdown_scroll()
 
     def cancel_option(self) -> None:
         self._dropdown = None
         self.dropdown_index = 0
+        self._dropdown_scroll = 0
 
     def commit_option(self) -> None:
         if self._dropdown is None:
@@ -728,6 +822,7 @@ class ConfigPanelModel:
         choice = self._dropdown["options"][self.dropdown_index]
         self._dropdown = None
         self.dropdown_index = 0
+        self._dropdown_scroll = 0
         if row.path == "llm.provider":
             if choice != self.draft.llm.provider:
                 self.draft = apply_provider_preset(self.draft, choice)
@@ -805,7 +900,7 @@ class ConfigPanelModel:
         self.row_error = ""
         self._expanded.update({"mcp", f"mcp.{name}"})
         self._focus_key = f"mcp.{name}"
-        self._ensure_focus_in_view()
+        self._ensure_focus_in_view(self._panel_viewport_rows())
 
     def delete_server(self) -> None:
         row = self.focused
@@ -820,7 +915,7 @@ class ConfigPanelModel:
         self._expanded.discard(f"mcp.{name}")
         self._focus_key = "mcp"
         self.row_error = ""
-        self._ensure_focus_in_view()
+        self._ensure_focus_in_view(self._panel_viewport_rows())
 
     # -- validation / save / summary --------------------------------------
 

--- a/vulnclaw/cli/config_panel_render.py
+++ b/vulnclaw/cli/config_panel_render.py
@@ -9,7 +9,7 @@ from rich.table import Table
 from rich.text import Text
 
 from vulnclaw.cli.config_panel import ConfigPanelModel, Row
-from vulnclaw.cli.tui import C_BORDER, C_ERROR, C_MUTED, C_PRIMARY, C_TEXT
+from vulnclaw.cli.tui import C_BORDER, C_ERROR, C_MUTED, C_PRIMARY, C_TEXT, C_WARNING
 from vulnclaw.i18n import _
 
 
@@ -47,13 +47,18 @@ def render_panel(model: ConfigPanelModel) -> Group:
             label.stylize(f"bold {C_PRIMARY}")
         table.add_row(mark, label, _row_value(model, row, focused))
         if focused and model.dropdown_open:
-            for index, option in enumerate(model.dropdown_options):
-                opt_mark = "›" if index == model.dropdown_index else " "
-                table.add_row(
-                    " ",
-                    Text(f"{indent}  {opt_mark} {option}", style=C_MUTED),
-                    "",
+            for index, option in model.visible_dropdown_options():
+                selected = index == model.dropdown_index
+                # Selected cursor uses C_WARNING (orange); unselected stays blank.
+                # Option text stays muted unless selected so the cursor stands out.
+                opt_mark: str | Text = (
+                    Text("›", style=f"bold {C_WARNING}") if selected else " "
                 )
+                opt_label = Text(
+                    f"{indent}  {option}",
+                    style=C_TEXT if selected else C_MUTED,
+                )
+                table.add_row(opt_mark, opt_label, "")
 
     body: list[object] = [table]
     llm_open = any(row.key == "action.fetch_models" for row in model.rows())

--- a/vulnclaw/cli/main.py
+++ b/vulnclaw/cli/main.py
@@ -64,6 +64,7 @@ from vulnclaw.cli._helpers import (
     _run_cli_orchestrated_task,
     console,
     err_console,
+    format_llm_user_error,
 )
 from vulnclaw.cli.manual import available_topics, render_manual
 from vulnclaw.config.schema import ENGINE_CHOICES
@@ -806,7 +807,7 @@ def _run_repl() -> None:
                 # Escape Rich markup chars in exception message to prevent MarkupError
                 from rich.markup import escape as rich_escape
 
-                console.print(_("cli.error", msg=rich_escape(str(e))))
+                console.print(_("cli.error", msg=rich_escape(format_llm_user_error(e))))
 
         except KeyboardInterrupt:
             now = time.monotonic()

--- a/vulnclaw/cli/tui.py
+++ b/vulnclaw/cli/tui.py
@@ -2601,6 +2601,78 @@ def run_config_tui() -> None:
     _run_config_wizard()
 
 
+def _read_system_clipboard() -> str | None:
+    """Read the OS clipboard without a third-party dependency.
+
+    Returns ``None`` when the clipboard cannot be read, or an empty string when
+    it is readable but empty. Windows goes through a temp UTF-8 file so the
+    console codepage cannot mangle non-ASCII; Unix tries the usual helpers.
+    """
+    import tempfile
+
+    if sys.platform == "win32":
+        tmp = Path(tempfile.gettempdir()) / f"vulnclaw-paste-{os.getpid()}.txt"
+        # Single-quoted PowerShell path; escape any embedded single quotes.
+        ps_path = str(tmp).replace("'", "''")
+        ps = (
+            "$text = Get-Clipboard -Raw; if ($null -eq $text) { $text = '' }; "
+            f"Set-Content -LiteralPath '{ps_path}' -Value $text -Encoding utf8 -NoNewline"
+        )
+        raw: bytes | None = None
+        try:
+            completed = subprocess.run(
+                [
+                    "powershell.exe",
+                    "-NoProfile",
+                    "-NonInteractive",
+                    "-WindowStyle",
+                    "Hidden",
+                    "-Command",
+                    ps,
+                ],
+                check=False,
+                capture_output=True,
+                timeout=5,
+            )
+            if completed.returncode == 0:
+                raw = tmp.read_bytes()
+        except (OSError, subprocess.SubprocessError):
+            raw = None
+        finally:
+            try:
+                tmp.unlink(missing_ok=True)
+            except OSError:
+                pass
+        if raw is None:
+            return None
+        if raw.startswith(b"\xef\xbb\xbf"):
+            raw = raw[3:]
+        try:
+            return raw.decode("utf-8")
+        except UnicodeDecodeError:
+            return None
+
+    for command in (
+        ("pbpaste",),
+        ("wl-paste", "--no-newline"),
+        ("xclip", "-selection", "clipboard", "-o"),
+        ("xsel", "--clipboard", "--output"),
+    ):
+        try:
+            completed = subprocess.run(
+                command,
+                check=False,
+                capture_output=True,
+                timeout=5,
+            )
+        except (OSError, subprocess.SubprocessError):
+            continue
+        if completed.returncode != 0:
+            continue
+        return completed.stdout.decode("utf-8", errors="replace")
+    return None
+
+
 def _run_config_panel() -> None:
     """Full-screen keyboard-navigable config panel."""
     import threading
@@ -2647,6 +2719,16 @@ def _run_config_panel() -> None:
             model.select_option(1)
         elif not model.editing:
             model.focus_next()
+
+    @kb.add("pageup")
+    def _pageup(event: Any) -> None:
+        if model.dropdown_open:
+            model.select_option(-model._dropdown_window_height())
+
+    @kb.add("pagedown")
+    def _pagedown(event: Any) -> None:
+        if model.dropdown_open:
+            model.select_option(model._dropdown_window_height())
 
     @kb.add("tab")
     def _tab(event: Any) -> None:
@@ -2755,6 +2837,19 @@ def _run_config_panel() -> None:
     def _backspace(event: Any) -> None:
         if model.editing:
             model.set_edit_text(model.edit_text[:-1])
+
+    @kb.add("c-v", eager=True)
+    def _ctrl_v(event: Any) -> None:
+        # Windows terminals often deliver Ctrl+V instead of bracketed paste.
+        # Read the system clipboard ourselves and feed the panel editor.
+        if model.editing:
+            model.apply_clipboard(_read_system_clipboard())
+
+    @kb.add("<bracketed-paste>", eager=True)
+    def _bracketed_paste(event: Any) -> None:
+        # Override the default Buffer paste so text lands in model.edit_text.
+        if model.editing:
+            model.paste_text(event.data)
 
     @kb.add("<any>")
     def _typed(event: Any) -> None:


### PR DESCRIPTION
Fixes #261.

## Problem

Classic `/config` edits one printable character at a time. Bracketed paste and Windows Ctrl+V never reach `edit_text`, so a pasted API key is dropped. Fetching an OpenRouter-sized model list then paints every option inline and shoves the rest of the panel off-screen.

## Approach

- `paste_text` / `apply_clipboard` on the panel model; Ctrl+V and bracketed paste feed them. List/env fields treat newlines as item separators.
- Dropdown options are windowed against the same viewport budget as the panel rows (PageUp/PageDown move by that window).
- REPL errors prefer OpenRouter `metadata.raw` over the generic "Provider returned error" blob.

`config_panel.py` still has no UI library and no I/O. Clipboard reading lives in `tui.py` and is tested with fake subprocesses.

## Verification

```
ruff check vulnclaw/cli/config_panel.py vulnclaw/cli/config_panel_render.py vulnclaw/cli/_helpers.py vulnclaw/cli/tui.py vulnclaw/cli/main.py tests/cli/test_config_panel.py tests/cli/test_config_panel_paste.py tests/cli/test_config_panel_render.py tests/cli/test_format_llm_user_error.py
pytest -q tests/cli/test_config_panel.py tests/cli/test_config_panel_paste.py tests/cli/test_config_panel_render.py tests/cli/test_format_llm_user_error.py
# 77 passed
```