### PR TITLE
feat(web): add HTTPS VPS compose profile

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -70,3 +70,7 @@ VULNCLAW_LLM_MODEL=gpt-4o
 # Already defaulted to /data (the mounted volume) in the image; override
 # only if you change the volume mount point.
 #VULNCLAW_CONFIG_DIR=/data
+
+# Public Web UI (VPS Compose profile only). Point this domain's A/AAAA record
+# at the VPS before starting docker-compose.vps.yml; Caddy manages TLS.
+#VULNCLAW_DOMAIN=vulnclaw.example.com

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -15,6 +15,31 @@ Then open <http://127.0.0.1:7788>.
 
 State persists in the `vulnclaw-data` named volume across restarts.
 
+## VPS deployment (HTTPS + mobile browser)
+
+Use the VPS Compose file rather than publishing port 7788 directly. It keeps
+VulnClaw on an internal Docker network, puts Caddy in front of it for automatic
+HTTPS, and marks the browser session cookie `Secure`.
+
+1. Create an A/AAAA DNS record for a domain pointing to the VPS, and allow TCP
+   ports 80 and 443 through the VPS firewall/security group.
+2. Copy `.env.example` to `.env`, add the LLM credentials, and set
+   `VULNCLAW_DOMAIN` to that domain.
+3. Start the stack:
+
+   ```bash
+   docker compose -f docker-compose.vps.yml up -d --build
+   docker compose -f docker-compose.vps.yml logs -f vulnclaw
+   ```
+
+   The logs print a one-time `https://<domain>/?token=...` sign-in URL. Open it
+   on the mobile browser once; it immediately removes the token from the URL
+   and stores an HttpOnly, SameSite=Strict, Secure session cookie.
+
+Only Caddy exposes ports 80/443; do not add a public `7788` mapping. Keep the
+printed token private, and rotate it by replacing `/data/.vulnclaw/web_token`
+inside the persistent volume if it is exposed.
+
 ## Quick start (plain docker)
 
 ```bash

--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -1,0 +1,10 @@
+{$VULNCLAW_DOMAIN} {
+	encode zstd gzip
+
+	header {
+		Strict-Transport-Security "max-age=31536000; includeSubDomains"
+		-Server
+	}
+
+	reverse_proxy vulnclaw:7788
+}

--- a/docker-compose.vps.yml
+++ b/docker-compose.vps.yml
@@ -1,0 +1,49 @@
+services:
+  vulnclaw:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: vulnclaw:latest
+    env_file:
+      - path: .env
+        required: false
+    environment:
+      # Caddy terminates TLS. The app still requires its token on every API call.
+      VULNCLAW_WEB_COOKIE_SECURE: "true"
+      VULNCLAW_WEB_PUBLIC_URL: https://${VULNCLAW_DOMAIN:?Set VULNCLAW_DOMAIN in .env}
+    volumes:
+      - vulnclaw-data:/data
+    restart: unless-stopped
+    init: true
+    security_opt:
+      - no-new-privileges:true
+    networks:
+      - backend
+
+  caddy:
+    image: caddy:2.8.4-alpine
+    environment:
+      VULNCLAW_DOMAIN: ${VULNCLAW_DOMAIN:?Set VULNCLAW_DOMAIN in .env}
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./deploy/Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy-data:/data
+      - caddy-config:/config
+    restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    networks:
+      - public
+      - backend
+
+networks:
+  public:
+  backend:
+    internal: true
+
+volumes:
+  vulnclaw-data:
+  caddy-data:
+  caddy-config:

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,7 +2,8 @@
 <html lang="zh-CN">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <meta name="theme-color" content="#f6f9fe" />
     <title>VulnClaw Web UI</title>
     <script type="module" src="/src/main.tsx"></script>
   </head>

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -47,6 +47,7 @@ export function Sidebar<T extends string>({ activeView, activeNavView = activeVi
             className={`nav-item ${activeNavView === item.key ? "active" : ""}`}
             onClick={() => onSelectView(item.key)}
             title={item.label}
+            aria-label={item.label}
           >
             <span className="nav-icon" aria-hidden="true">
               <img src={item.icon} alt="" />

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -2877,7 +2877,7 @@ body {
     width: 100%;
     height: auto;
     grid-template-columns: auto minmax(0, 1fr);
-    padding: 10px 12px;
+    padding: max(10px, env(safe-area-inset-top)) max(12px, env(safe-area-inset-right)) 10px max(12px, env(safe-area-inset-left));
     z-index: 10;
   }
 
@@ -2901,12 +2901,16 @@ body {
     gap: 8px;
     overflow-x: auto;
     justify-items: start;
+    overscroll-behavior-x: contain;
+    scroll-snap-type: x proximity;
+    -webkit-overflow-scrolling: touch;
   }
 
   .nav-item {
     flex: 0 0 48px;
     width: 48px;
     height: 48px;
+    scroll-snap-align: start;
   }
 
   .nav-icon {
@@ -2921,7 +2925,7 @@ body {
   }
 
   .workspace {
-    padding: 12px;
+    padding: 12px max(12px, env(safe-area-inset-right)) max(24px, env(safe-area-inset-bottom)) max(12px, env(safe-area-inset-left));
   }
 
   .topbar {
@@ -2966,5 +2970,18 @@ body {
 
   .goby-scan-summary strong {
     justify-self: start;
+  }
+
+  button,
+  input,
+  select,
+  textarea {
+    min-height: 44px;
+  }
+
+  input,
+  select,
+  textarea {
+    font-size: 16px;
   }
 }

--- a/tests/web/test_auth.py
+++ b/tests/web/test_auth.py
@@ -131,3 +131,20 @@ class TestSessionCookie:
         assert f"{auth.SESSION_COOKIE}={token}" in header
         assert "HttpOnly" in header
         assert "samesite=strict" in header.lower()
+
+    def test_attach_session_cookie_can_require_https(self, monkeypatch, tmp_path):
+        import vulnclaw.web.app as web_app
+
+        if not web_app.FASTAPI_AVAILABLE:
+            import pytest
+
+            pytest.skip("FastAPI is not installed in this environment")
+
+        from starlette.responses import Response
+
+        _redirect_token_dir(monkeypatch, tmp_path)
+        monkeypatch.setenv("VULNCLAW_WEB_COOKIE_SECURE", "true")
+        response = Response()
+        auth.attach_session_cookie(response, auth.generate_token())
+
+        assert "secure" in response.headers["set-cookie"].lower()

--- a/tests/web/test_web.py
+++ b/tests/web/test_web.py
@@ -1431,6 +1431,28 @@ class TestWebApp:
         assert result.exit_code == 0
         assert "0.0.0.0" in result.output
 
+    def test_cli_web_uses_valid_https_public_url(self, monkeypatch):
+        from vulnclaw.cli.main import _web_public_url
+
+        monkeypatch.setenv("VULNCLAW_WEB_PUBLIC_URL", "https://vulnclaw.example.com/")
+        assert _web_public_url() == "https://vulnclaw.example.com"
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "http://vulnclaw.example.com",
+            "https://user@vulnclaw.example.com",
+            "https://vulnclaw.example.com/path",
+            "https://vulnclaw.example.com/?token=bad",
+            "https://vulnclaw.example.com/#fragment",
+        ],
+    )
+    def test_cli_web_rejects_unsafe_public_url(self, monkeypatch, value):
+        from vulnclaw.cli.main import _web_public_url
+
+        monkeypatch.setenv("VULNCLAW_WEB_PUBLIC_URL", value)
+        assert _web_public_url() is None
+
     def test_web_target_preview_and_diff_endpoints(self, monkeypatch):
         import vulnclaw.web.app as web_app
         import vulnclaw.web.auth as web_auth

--- a/vulnclaw/cli/main.py
+++ b/vulnclaw/cli/main.py
@@ -3713,11 +3713,13 @@ def web(
         # container through Docker's port NAT) must authenticate. The UI cannot
         # send a bearer header, so opening this URL once swaps the token for a
         # session cookie; the browser carries it from then on.
+        public_url = _web_public_url()
         browser_host = "127.0.0.1" if host in {"0.0.0.0", "::", "[::]"} else host
+        browser_url = public_url or f"http://{browser_host}:{port}"
         console.print(
             Panel(
                 f"Open this URL once to sign the browser in:\n"
-                f"[bold]http://{browser_host}:{port}/?token={token}[/]\n\n"
+                f"[bold]{browser_url}/?token={token}[/]\n\n"
                 f"Token: [bold]{token}[/]\n"
                 f"[dim]For API clients: Authorization: Bearer {token}[/]",
                 title="Web UI Auth Token",
@@ -3739,6 +3741,30 @@ def _is_loopback_bind_host(host: str) -> bool:
         return ipaddress.ip_address(normalized).is_loopback
     except ValueError:
         return False
+
+
+def _web_public_url() -> str | None:
+    """Return a safe operator-facing HTTPS URL configured for a reverse proxy."""
+    from urllib.parse import urlsplit
+
+    value = os.environ.get("VULNCLAW_WEB_PUBLIC_URL", "").strip().rstrip("/")
+    if not value:
+        return None
+    parsed = urlsplit(value)
+    if (
+        parsed.scheme != "https"
+        or not parsed.netloc
+        or parsed.username
+        or parsed.password
+        or parsed.path
+        or parsed.query
+        or parsed.fragment
+    ):
+        err_console.print(
+            "[yellow]Ignoring invalid VULNCLAW_WEB_PUBLIC_URL; expected an HTTPS origin.[/]"
+        )
+        return None
+    return value
 
 
 if __name__ == "__main__":

--- a/vulnclaw/web/auth.py
+++ b/vulnclaw/web/auth.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import hmac
 import ipaddress
+import os
 import secrets
 from pathlib import Path
 
@@ -77,13 +78,28 @@ def verify_token(token: str) -> bool:
     return hmac.compare_digest(stored, token)
 
 
-def attach_session_cookie(response, token: str) -> None:  # type: ignore[no-untyped-def]
+def web_cookie_secure() -> bool:
+    """Whether browser sessions must be limited to HTTPS connections.
+
+    The local UI intentionally supports plain HTTP.  A reverse-proxied VPS
+    deployment sets ``VULNCLAW_WEB_COOKIE_SECURE=true`` so a copied session
+    cookie cannot be replayed over HTTP.
+    """
+    return os.environ.get("VULNCLAW_WEB_COOKIE_SECURE", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
+def attach_session_cookie(response, token: str, *, secure: bool | None = None) -> None:  # type: ignore[no-untyped-def]
     """Store *token* on the browser as an HttpOnly session cookie.
 
-    ``secure`` is deliberately left off: the UI is served over plain HTTP on
-    localhost and inside Docker, where a Secure cookie would never be sent
-    back. ``SameSite=Strict`` keeps the cookie off cross-site requests, which
-    is what guards the state-changing ``/api/`` routes against CSRF.
+    ``secure`` defaults from ``VULNCLAW_WEB_COOKIE_SECURE``.  Local HTTP keeps
+    working by default; the VPS Compose profile enables it after TLS is
+    terminated by Caddy. ``SameSite=Strict`` keeps the cookie off cross-site
+    requests, guarding state-changing ``/api/`` routes against CSRF.
     """
     response.set_cookie(
         SESSION_COOKIE,
@@ -91,6 +107,7 @@ def attach_session_cookie(response, token: str) -> None:  # type: ignore[no-unty
         httponly=True,
         samesite="strict",
         path="/",
+        secure=web_cookie_secure() if secure is None else secure,
     )
 
 


### PR DESCRIPTION
Fixes #263.

## Problem

`docker-compose.yml` publishes 127.0.0.1:7788. Fine locally; on a VPS it puts the app on a public HTTP port, and the session cookie is not `Secure`, so a copied cookie can be replayed over HTTP.

## Approach

Opt-in `docker-compose.vps.yml`:

- VulnClaw stays on an internal Docker network
- Caddy terminates TLS on 80/443 (`deploy/Caddyfile`)
- `VULNCLAW_WEB_COOKIE_SECURE=true` and a validated `VULNCLAW_WEB_PUBLIC_URL`
- Sign-in URL printed as `https://<domain>/?token=...`

Local compose and the localhost cookie default are unchanged. Mobile CSS only adds safe-area / 44px tap targets.

## Verification

```
ruff check vulnclaw/web/auth.py vulnclaw/cli/main.py tests/web/test_auth.py tests/web/test_web.py
pytest -q tests/web/test_auth.py tests/web/test_web.py::TestWebApp::test_cli_web_uses_valid_https_public_url tests/web/test_web.py::TestWebApp::test_cli_web_rejects_unsafe_public_url
# 15 passed
```